### PR TITLE
feat: update snapshot schema with new field

### DIFF
--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -8,7 +8,7 @@
     "snapshots": "rm -rf cdk.out __snapshots__ && IS_SNAPSHOT=true cdk synth && cdk-create-snapshots"
   },
   "devDependencies": {
-    "@capraconsulting/cals-cli": "2.23.2",
+    "@capraconsulting/cals-cli": "2.24.0",
     "@types/node": "16.11.25",
     "@typescript-eslint/eslint-plugin": "5.12.0",
     "@typescript-eslint/parser": "5.12.0",

--- a/packages/repo-collector-types/src/index.ts
+++ b/packages/repo-collector-types/src/index.ts
@@ -3,6 +3,7 @@
 // over changes.
 export interface MetricRepoGitHubVulnerabilityAlert {
   dismissReason: string | null
+  state: "DISMISSED" | "FIXED" | "OPEN"
   vulnerableManifestFilename: string
   vulnerableManifestPath: string
   vulnerableRequirements: string | null

--- a/packages/repo-collector-types/src/index.ts
+++ b/packages/repo-collector-types/src/index.ts
@@ -41,7 +41,7 @@ export interface MetricRepoGitHubVulnerabilityAlert {
  * A snapshot of a specific repo with embedded related details.
  */
 export interface MetricRepoSnapshot {
-  version: "1"
+  version: "1.1"
   timestamp: string
   repoId: string
   responsible?: string

--- a/packages/repo-collector/package.json
+++ b/packages/repo-collector/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/client-cloudfront": "3.52.0",
     "@aws-sdk/client-s3": "3.52.0",
     "@aws-sdk/client-secrets-manager": "3.52.0",
-    "@capraconsulting/cals-cli": "2.23.2",
+    "@capraconsulting/cals-cli": "2.24.0",
     "@js-temporal/polyfill": "0.3.0",
     "@liflig/repo-metrics-repo-collector-types": "0.0.0-development",
     "@types/lodash": "4.14.178",

--- a/packages/repo-collector/src/reporter/reporter.ts
+++ b/packages/repo-collector/src/reporter/reporter.ts
@@ -215,6 +215,9 @@ function sumSnykSeverities(
 
 function sumGithubVuls(datapoint: MetricRepoSnapshot): number {
   return datapoint.github.vulnerabilityAlerts.filter(
-    (it) => it.dismissReason == null,
+    // We need to handle multiple snapshot versions here:
+    // Earlier snapshots are missing the `state` field, and rely on `dismissReason`
+    // to determine if a vulnerability is open or not.
+    (it) => (it.state == null ? it.dismissReason == null : it.state === "OPEN"),
   ).length
 }

--- a/packages/repo-collector/src/snapshots/collect.ts
+++ b/packages/repo-collector/src/snapshots/collect.ts
@@ -78,7 +78,7 @@ async function createSnapshots(
     }))
 
     result.push({
-      version: "1",
+      version: "1.1",
       timestamp: timestamp.toString(),
       repoId,
       responsible: repo.repo.repo.responsible ?? repo.repo.project.responsible,

--- a/packages/repo-collector/src/webapp/webapp.ts
+++ b/packages/repo-collector/src/webapp/webapp.ts
@@ -89,7 +89,9 @@ function convertDatapoint(
         createdAt: pr.createdAt,
       })),
       vulnerabilityAlerts: datapoint.github.vulnerabilityAlerts
-        .filter((it) => it.dismissReason == null)
+        .filter((it) =>
+          it.state == null ? it.dismissReason == null : it.state === "OPEN",
+        )
         .map((va) => ({
           vulnerableManifestPath: va.vulnerableManifestPath,
           severity: va.securityAdvisory?.severity,
@@ -177,8 +179,8 @@ export function createWebappFriendlyFormat(
       repoId: it.repoId,
       responsible: it.responsible ?? "Ukjent",
       updates: getAvailableActionableUpdates(it),
-      githubVulnerabilities: it.github.vulnerabilityAlerts.filter(
-        (it) => it.dismissReason == null,
+      githubVulnerabilities: it.github.vulnerabilityAlerts.filter((it) =>
+        it.state == null ? it.dismissReason == null : it.state === "OPEN",
       ).length,
       snykVulnerabilities: sumBy(
         it.snyk.projects,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1814,10 +1814,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@capraconsulting/cals-cli@2.23.2":
-  version "2.23.2"
-  resolved "https://registry.yarnpkg.com/@capraconsulting/cals-cli/-/cals-cli-2.23.2.tgz#b64f45265182aa1d5078428a3813370498986f72"
-  integrity sha512-rPD03reNYJFoPXYNYrQqH/W8apqdCByKrPJ7O1lHLYHZhNoqUnRihX5V7S0lEVVEDELAAphg6l58wGTXZfbUaA==
+"@capraconsulting/cals-cli@2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@capraconsulting/cals-cli/-/cals-cli-2.24.0.tgz#155e6ccfd20b29d12b9cf41ab6a83f75339d0462"
+  integrity sha512-oHuNYW8YDjGgh1n1292rXaGvZtC1D/1+FA+/LzJE+gzpq9qb6RpiSjliv6QUgmsLgmF0i3m8e7uadDUEQWhCTA==
   dependencies:
     "@aws-sdk/client-secrets-manager" "^3.16.0"
     "@aws-sdk/client-sts" "^3.16.0"
@@ -3202,7 +3202,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
   integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
 
-"@types/eslint-scope@^3.7.0", "@types/eslint-scope@^3.7.3":
+"@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
   integrity sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==
@@ -3222,11 +3222,6 @@
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
-
-"@types/estree@^0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
-  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
   version "4.17.28"
@@ -3450,15 +3445,6 @@
   integrity sha512-T6UeAUQWojf1toimSIf6sBwaO4HQ4iHdF4BL2RbPbzKTqe5blB7Iih7i7h69NSg/fOjWlkdszNPlaWD1/aX5LQ==
   dependencies:
     webpack-dev-server "*"
-
-"@types/webpack@^5.18.0":
-  version "5.28.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
-  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
-  dependencies:
-    "@types/node" "*"
-    tapable "^2.2.0"
-    webpack "^5"
 
 "@types/ws@^8.2.2":
   version "8.2.2"
@@ -12366,36 +12352,6 @@ webpack@5.69.1:
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/wasm-edit" "1.11.1"
-    "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
-    acorn-import-assertions "^1.7.6"
-    browserslist "^4.14.5"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
-    es-module-lexer "^0.9.0"
-    eslint-scope "5.1.1"
-    events "^3.2.0"
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.9"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^4.2.0"
-    mime-types "^2.1.27"
-    neo-async "^2.6.2"
-    schema-utils "^3.1.0"
-    tapable "^2.1.1"
-    terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.1"
-    webpack-sources "^3.2.3"
-
-webpack@^5:
-  version "5.68.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.68.0.tgz#a653a58ed44280062e47257f260117e4be90d560"
-  integrity sha512-zUcqaUO0772UuuW2bzaES2Zjlm/y3kRBQDVFVCge+s2Y8mwuUTdperGaAv65/NtRL/1zanpSJOq/MD8u61vo6g==
-  dependencies:
-    "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.50"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"


### PR DESCRIPTION
A new field `state` has been added to the GitHub API for vulnerability alerts. This field allows us to more easily determine if a vulnerability in a given repository is open, fixed or dismissed.

We've previously used the field `dismissReason` to determine if a vulnerability can be considered handled or not, but with the new API changes, this won't work as it previously did. (E.g., a fixed vulnerability will have `dismissReason` set to `null`).

Unlike `dismissReason`, the field `state` is non-nullable (i.e., *always* defined) and it's probably a good idea to use this field as the source-of-truth for the status of a given vulnerability.

The changes introduced here should be backwards-compatible with the previous snapshots by falling back to `dismissReason` if the `state` field is missing , but I've bumped the snapshot version to signal that a change has been made.

https://github.com/capralifecycle/cals-cli/pull/145 needs to be merged first.