### PR TITLE
Alle filterinstillinger reflekteres i URL

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
           href="https://github.com/capralifecycle/liflig-repo-metrics"
           style={{ marginLeft: "5px" }}
         >
-	  GitHub
+          GitHub
         </a>
       </div>
       {dataIsLoading ? (

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -9,9 +9,9 @@ const App: React.FC = () => {
   const [filter, setFilter] = React.useState(defaultValues)
 
   React.useEffect(() => {
-    setFilter(getFilterFromUrl())
+    const initialFilter = getFilterFromUrl()
+    setFilter(initialFilter)
   }, [])
-
   return (
     <>
       <div style={{ display: "flex", alignItems: "center" }}>
@@ -20,7 +20,7 @@ const App: React.FC = () => {
           href="https://github.com/capralifecycle/liflig-repo-metrics"
           style={{ marginLeft: "5px" }}
         >
-          GitHub
+	  GitHub
         </a>
       </div>
       {dataIsLoading ? (

--- a/packages/webapp/src/DataList.tsx
+++ b/packages/webapp/src/DataList.tsx
@@ -52,11 +52,11 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
     history.replaceState(state, "", queryString ? `?${queryString}` : "/")
   }, [state])
 
-  const limitDays = 30
+  //const limitDays = 30
 
-  const [limitGraphDays, setLimitGraphDays] = React.useState<number | null>(
-    limitDays,
-  )
+  //const [limitGraphDays, setLimitGraphDays] = React.useState<number | null>(
+  //  limitDays,
+  //)
 
   const actionableRepos = state.showOnlyActionable
 			? data.repos
@@ -106,7 +106,7 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
   const filteredFetchGroups = filterFetchGroupRepos(
     data.byFetchGroup.filter(
       (it) =>
-        limitGraphDays == null || ageInDays(it.timestamp) < limitGraphDays,
+        state.limitGraphDays == null || ageInDays(it.timestamp) < state.limitGraphDays,
     ),
     (it) => shownRepoIds.includes(it.repoId),
   )
@@ -178,8 +178,13 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
 	  Vis kun sårbare repoer
         </Checkbox>
         <Checkbox
-          checked={limitGraphDays != null}
-          onCheck={(checked) => setLimitGraphDays(checked ? limitDays : null)}
+          checked={state.limitGraphDays != null}
+          onCheck={(checked) => {
+	    dispatch({
+	      type: FilterActionType.TOGGLE_LAST_30_DAYS,
+	      prop: "limitGraphDays",
+	    })
+	  }}
         >
 	  Begrens graf til siste 30 dager
         </Checkbox>

--- a/packages/webapp/src/DataList.tsx
+++ b/packages/webapp/src/DataList.tsx
@@ -18,10 +18,10 @@ interface Props {
 
 function ageInDays(timestamp: string) {
   // Approx to simplify.
-  const secondsPerDay = 86400000;
+  const secondsPerDay = 86400000
   return Math.floor(
-    (new Date().getTime() - new Date(timestamp).getTime()) / secondsPerDay
-  );
+    (new Date().getTime() - new Date(timestamp).getTime()) / secondsPerDay,
+  )
 }
 
 function filterFetchGroupRepos(
@@ -52,23 +52,17 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
     history.replaceState(state, "", queryString ? `?${queryString}` : "/")
   }, [state])
 
-  //const limitDays = 30
-
-  //const [limitGraphDays, setLimitGraphDays] = React.useState<number | null>(
-  //  limitDays,
-  //)
-
   const actionableRepos = state.showOnlyActionable
-			? data.repos
-			      .filter((it) => isActionableRepo(it.lastDatapoint))
-			      .map((it) => it.repoId)
-			: []
+    ? data.repos
+        .filter((it) => isActionableRepo(it.lastDatapoint))
+        .map((it) => it.repoId)
+    : []
 
   const vulnerableRepos = state.showOnlyVulnerable
-			? data.repos
-			      .filter((it) => isVulnerableRepo(it.lastDatapoint))
-			      .map((it) => it.repoId)
-			: []
+    ? data.repos
+        .filter((it) => isVulnerableRepo(it.lastDatapoint))
+        .map((it) => it.repoId)
+    : []
 
   function filterRepoId(repoId: string): boolean {
     return (
@@ -82,9 +76,11 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
     return (
       state.filterUpdateName === "" ||
       (repo.lastDatapoint.github.availableUpdates?.some((category) =>
-        category.updates.some((update) => update.name.includes(state.filterUpdateName)),
+        category.updates.some((update) =>
+          update.name.includes(state.filterUpdateName),
+        ),
       ) ??
-       false)
+        false)
     )
   }
 
@@ -98,22 +94,23 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
   }
 
   const filteredRepos = data.repos
-			    .filter((it) => filterRepoId(it.repoId))
-			    .filter((it) => filterByUpdates(it) || filterByVulnerabilities(it))
+    .filter((it) => filterRepoId(it.repoId))
+    .filter((it) => filterByUpdates(it) || filterByVulnerabilities(it))
 
   const shownRepoIds = filteredRepos.map((it) => it.repoId)
 
   const filteredFetchGroups = filterFetchGroupRepos(
     data.byFetchGroup.filter(
       (it) =>
-        state.limitGraphDays == null || ageInDays(it.timestamp) < state.limitGraphDays,
+        state.limitGraphDays == null ||
+        ageInDays(it.timestamp) < state.limitGraphDays,
     ),
     (it) => shownRepoIds.includes(it.repoId),
   )
 
   const byResponsible = state.groupByResponsible
-		      ? groupBy(filteredRepos, (it) => it.responsible ?? "Ukjent")
-		      : undefined
+    ? groupBy(filteredRepos, (it) => it.responsible ?? "Ukjent")
+    : undefined
 
   const createOnCheckHandler = (prop: keyof Filter) => () =>
     dispatch({
@@ -128,28 +125,27 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
           checked={state.groupByResponsible}
           onCheck={createOnCheckHandler("groupByResponsible")}
         >
-	  Grupper etter ansvarlig (iht.{" "}
-	  <a href="https://github.com/capralifecycle/resources-definition">
-	    resources-definition
-	  </a>
-	  )
+          Grupper etter ansvarlig (iht.{" "}
+          <a href="https://github.com/capralifecycle/resources-definition">
+            resources-definition
+          </a>
+          )
         </Checkbox>
         <Checkbox
           checked={state.showDepList}
           onCheck={createOnCheckHandler("showDepList")}
         >
-	  Vis detaljert liste over oppdateringer
+          Vis detaljert liste over oppdateringer
         </Checkbox>
         <input
           type="text"
           value={state.filterUpdateName}
           onChange={(e) => {
-	    dispatch({
-	      type: FilterActionType.CHANGE_SEARCH_FILTER,
-	      prop: "filterUpdateName",
-	      payload: e.target.value
-	    })
-	    
+            dispatch({
+              type: FilterActionType.CHANGE_SEARCH_FILTER,
+              prop: "filterUpdateName",
+              payload: e.target.value,
+            })
           }}
           placeholder="Filtrer på navn til oppdatering"
         />
@@ -157,106 +153,106 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
           checked={state.showPrList}
           onCheck={createOnCheckHandler("showPrList")}
         >
-	  Vis liste over PRs
+          Vis liste over PRs
         </Checkbox>
         <Checkbox
           checked={state.showVulList}
           onCheck={createOnCheckHandler("showVulList")}
         >
-	  Vis detaljer om sårbarheter
+          Vis detaljer om sårbarheter
         </Checkbox>
         <Checkbox
           checked={state.showOnlyActionable}
           onCheck={createOnCheckHandler("showOnlyActionable")}
         >
-	  Skjul repoer hvor alt er OK nå
+          Skjul repoer hvor alt er OK nå
         </Checkbox>
         <Checkbox
           checked={state.showOnlyVulnerable}
           onCheck={createOnCheckHandler("showOnlyVulnerable")}
         >
-	  Vis kun sårbare repoer
+          Vis kun sårbare repoer
         </Checkbox>
         <Checkbox
           checked={state.limitGraphDays != null}
           onCheck={(checked) => {
-	    dispatch({
-	      type: FilterActionType.TOGGLE_LAST_30_DAYS,
-	      prop: "limitGraphDays",
-	    })
-	  }}
+            dispatch({
+              type: FilterActionType.TOGGLE_LAST_30_DAYS,
+              prop: "limitGraphDays",
+            })
+          }}
         >
-	  Begrens graf til siste 30 dager
+          Begrens graf til siste 30 dager
         </Checkbox>
         <Checkbox
           checked={state.sortByRenovateDays}
           onCheck={createOnCheckHandler("sortByRenovateDays")}
         >
-	  Vis alle Renovate dager og sorter baklengs
+          Vis alle Renovate dager og sorter baklengs
         </Checkbox>
         <input
           type="text"
           value={state.filterRepoName}
           onChange={(e) => {
-	    dispatch({
-	      type: FilterActionType.CHANGE_SEARCH_FILTER,
-	      prop: "filterRepoName",
-	      payload: e.target.value
-	    });
+            dispatch({
+              type: FilterActionType.CHANGE_SEARCH_FILTER,
+              prop: "filterRepoName",
+              payload: e.target.value,
+            })
           }}
           placeholder="Filtrer på navn til repo"
         />
       </div>
       {byResponsible != null ? (
         Object.entries(byResponsible)
-	      .sort((a, b) => a[0].localeCompare(b[0]))
-	      .map(([responsible, repos]) => {
-		const collapsed = state.collapseResponsible.includes(responsible)
+          .sort((a, b) => a[0].localeCompare(b[0]))
+          .map(([responsible, repos]) => {
+            const collapsed = state.collapseResponsible.includes(responsible)
 
-		return (
-		  <React.Fragment key={responsible}>
-		    <div className="responsible-heading">
-		      <h2>Ansvarlig: {responsible}</h2>
-		      <button
-			style={{ marginLeft: "5px" }}
-			onClick={() =>
-			  dispatch({
-			    type: FilterActionType.TOGGLE_COLLAPSE_RESPONSIBLE,
-			    prop: "collapseResponsible",
-			    payload: responsible,
-			  })
-			}
-		      >
-			{collapsed ? "Vis" : "Skjul"}
-		      </button>
-		    </div>
-		    {!collapsed && (
-		      <DataGroup
-			key={responsible}
-			fetchGroups={filterFetchGroupRepos(
-			  filteredFetchGroups,
-			  (it) => it.responsible === responsible,
-			)}
-			repos={repos}
-			showPrList={state.showPrList}
-			showDepList={state.showDepList}
-			showVulList={state.showVulList}
-			sortByRenovateDays={state.sortByRenovateDays}
-		      />
-		    )}
-		  </React.Fragment>
-		)
-	      })
+            return (
+              <React.Fragment key={responsible}>
+                <div className="responsible-heading">
+                  <h2>Ansvarlig: {responsible}</h2>
+                  <button
+                    style={{ marginLeft: "5px" }}
+                    onClick={() =>
+                      dispatch({
+                        type: FilterActionType.TOGGLE_COLLAPSE_RESPONSIBLE,
+                        prop: "collapseResponsible",
+                        payload: responsible,
+                      })
+                    }
+                  >
+                    {collapsed ? "Vis" : "Skjul"}
+                  </button>
+                </div>
+                {!collapsed && (
+                  <DataGroup
+                    key={responsible}
+                    fetchGroups={filterFetchGroupRepos(
+                      filteredFetchGroups,
+                      (it) => it.responsible === responsible,
+                    )}
+                    repos={repos}
+                    showPrList={state.showPrList}
+                    showDepList={state.showDepList}
+                    showVulList={state.showVulList}
+                    sortByRenovateDays={state.sortByRenovateDays}
+                  />
+                )}
+              </React.Fragment>
+            )
+          })
       ) : (
         <>
           <h2 className="all-repos-heading">Alle repoer</h2>
           <DataGroup
-	    fetchGroups={filteredFetchGroups}
-	    repos={filteredRepos}
-	    showPrList={state.showPrList}
-	    showDepList={state.showDepList}
-	    showVulList={state.showVulList}
-	    sortByRenovateDays={state.sortByRenovateDays}
+            fetchGroups={filteredFetchGroups}
+            repos={filteredRepos}
+            showPrList={state.showPrList}
+            showDepList={state.showDepList}
+            showVulList={state.showVulList}
+            sortByRenovateDays={state.sortByRenovateDays}
           />
         </>
       )}

--- a/packages/webapp/src/filter.ts
+++ b/packages/webapp/src/filter.ts
@@ -59,7 +59,6 @@ const parseUrlFilterField = (key: string, value: string) => {
 
 
 export const toQueryString = (state: Filter): string => {
-  console.log(Object.keys(defaultValues))
   return Object.keys(defaultValues)
     .filter((k) => !_.isEqual(defaultValues[k], state[k]))
     .map((k) => `${k}=${state[k].toString()}`)

--- a/packages/webapp/src/filter.ts
+++ b/packages/webapp/src/filter.ts
@@ -1,6 +1,6 @@
 import _ from "lodash"
 
-export interface Filter extends Record<string, boolean | string[]> {
+export interface Filter extends Record<string, boolean | string | string[]> {
   showPrList: boolean
   showDepList: boolean
   showVulList: boolean
@@ -9,6 +9,8 @@ export interface Filter extends Record<string, boolean | string[]> {
   showOnlyVulnerable: boolean
   sortByRenovateDays: boolean
   collapseResponsible: string[]
+  filterRepoName: string
+  filterUpdateName: string
 }
 
 export const defaultValues: Filter = {
@@ -20,6 +22,8 @@ export const defaultValues: Filter = {
   showOnlyVulnerable: false,
   sortByRenovateDays: false,
   collapseResponsible: [],
+  filterRepoName: "",
+  filterUpdateName: ""
 }
 
 export const getFilterFromUrl = (): Filter =>
@@ -29,14 +33,35 @@ export const getFilterFromUrl = (): Filter =>
     .map((s) => s.split("="))
     .reduce(
       (acc, [k, v]) =>
-        Object.assign(acc, {
-          [k]: k == "collapseResponsible" ? v.split(",") : v === "true",
-        }),
+        Object.assign(
+          acc, parseUrlFilterField(k, v)
+        ),
       Object.assign({}, defaultValues),
     )
 
-export const toQueryString = (state: Filter): string =>
-  Object.keys(defaultValues)
+const parseUrlFilterField = (key: string, value: string) => {
+  if (key == "collapseResponsible") {
+    return {
+      [key]: value.split(",")
+    }
+  }
+  else if (key == "filterRepoName" || key == "filterUpdateName") {
+    return {
+      [key]: value
+    }
+  }
+  else {
+    return {
+      [key]: true
+    }
+  }
+}
+
+
+export const toQueryString = (state: Filter): string => {
+  console.log(Object.keys(defaultValues))
+  return Object.keys(defaultValues)
     .filter((k) => !_.isEqual(defaultValues[k], state[k]))
     .map((k) => `${k}=${state[k].toString()}`)
     .join("&")
+}

--- a/packages/webapp/src/filter.ts
+++ b/packages/webapp/src/filter.ts
@@ -1,6 +1,7 @@
 import _ from "lodash"
 
-export interface Filter extends Record<string, boolean | string | string[] | number | null> {
+export interface Filter
+  extends Record<string, boolean | string | string[] | number | null> {
   showPrList: boolean
   showDepList: boolean
   showVulList: boolean
@@ -25,7 +26,7 @@ export const defaultValues: Filter = {
   collapseResponsible: [],
   filterRepoName: "",
   filterUpdateName: "",
-  limitGraphDays: null
+  limitGraphDays: null,
 }
 
 // Parse URL parameters and turn into a filter object.
@@ -36,39 +37,39 @@ export const getFilterFromUrl = (): Filter =>
     .split("&")
     .map((s) => s.split("="))
     .reduce(
-      (acc, [k, v]) =>
-        Object.assign(
-          acc, parseUrlFilterField(k, v)
-        ),
+      (acc, [k, v]) => Object.assign(acc, parseUrlFilterField(k, v)),
       Object.assign({}, defaultValues),
     )
 
 const parseUrlFilterField = (key: string, value: string) => {
-  const keyValueFields = ["filterRepoName", "filterUpdateName", "limitGraphDays"]
+  const keyValueFields = [
+    "filterRepoName",
+    "filterUpdateName",
+    "limitGraphDays",
+  ]
 
   // The collapseResponsible attribute can contain multiple comma separated values,
   // and needs special handling during parsing
   if (key == "collapseResponsible") {
     return {
-      [key]: value.split(",")
+      [key]: value.split(","),
     }
   }
 
   // Attributes with only one value
   else if (keyValueFields.includes(key)) {
     return {
-      [key]: value
+      [key]: value,
     }
   }
 
   // Boolean attributes
   else {
     return {
-      [key]: true
+      [key]: true,
     }
   }
 }
-
 
 export const toQueryString = (state: Filter): string => {
   return Object.keys(defaultValues)

--- a/packages/webapp/src/filterReducer.ts
+++ b/packages/webapp/src/filterReducer.ts
@@ -28,11 +28,11 @@ export function filterReducer(state: Filter, action: FilterAction): Filter {
     }
     case FilterActionType.CHANGE_SEARCH_FILTER: {
 
-      // If the contents of the filter is empty, leave state as it is
-      if (action.payload === null || action.payload === "")
+      // Null check
+      if (action.payload === null)
         return state
 
-      // Otherwise, update filter state
+      // Non-null search filter values update filter state
       const newFilterValue: string = action.payload as string
       const newFilterState = {
         ...state, [action.prop]: newFilterValue

--- a/packages/webapp/src/filterReducer.ts
+++ b/packages/webapp/src/filterReducer.ts
@@ -3,6 +3,7 @@ import { Filter } from "./filter"
 export enum FilterActionType {
   TOGGLE_BOOLEAN = "toggle_boolean",
   TOGGLE_COLLAPSE_RESPONSIBLE = "toggle_collapse_responsible",
+  CHANGE_SEARCH_FILTER = "change_search_filter"
 }
 
 interface FilterAction<T = keyof Filter> {
@@ -25,6 +26,20 @@ export function filterReducer(state: Filter, action: FilterAction): Filter {
 
       return { ...state, collapseResponsible }
     }
+    case FilterActionType.CHANGE_SEARCH_FILTER: {
+
+      // If the contents of the filter is empty, leave state as it is
+      if (action.payload === null || action.payload === "")
+        return state
+
+      // Otherwise, update filter state
+      const newFilterValue: string = action.payload as string
+      const newFilterState = {
+        ...state, [action.prop]: newFilterValue
+      }
+      return newFilterState;
+    }
+
     default:
       throw new Error()
   }

--- a/packages/webapp/src/filterReducer.ts
+++ b/packages/webapp/src/filterReducer.ts
@@ -3,7 +3,8 @@ import { Filter } from "./filter"
 export enum FilterActionType {
   TOGGLE_BOOLEAN = "toggle_boolean",
   TOGGLE_COLLAPSE_RESPONSIBLE = "toggle_collapse_responsible",
-  CHANGE_SEARCH_FILTER = "change_search_filter"
+  CHANGE_SEARCH_FILTER = "change_search_filter",
+  TOGGLE_LAST_30_DAYS = "toggle_last_30_days"
 }
 
 interface FilterAction<T = keyof Filter> {
@@ -16,6 +17,21 @@ export function filterReducer(state: Filter, action: FilterAction): Filter {
   switch (action.type) {
     case FilterActionType.TOGGLE_BOOLEAN:
       return { ...state, [action.prop]: !state[action.prop] }
+
+    case FilterActionType.TOGGLE_LAST_30_DAYS: {
+      const curValue = state[action.prop]
+      let newValue = undefined
+      // Currently just a toggle between 30 days and null
+      if (curValue === null) {
+        newValue = 30
+      }
+      else {
+        newValue = null
+      }
+
+      return { ...state, [action.prop]: newValue }
+    }
+
     case FilterActionType.TOGGLE_COLLAPSE_RESPONSIBLE: {
       const responsible = action.payload
       if (!responsible) return state

--- a/packages/webapp/src/filterReducer.ts
+++ b/packages/webapp/src/filterReducer.ts
@@ -4,7 +4,7 @@ export enum FilterActionType {
   TOGGLE_BOOLEAN = "toggle_boolean",
   TOGGLE_COLLAPSE_RESPONSIBLE = "toggle_collapse_responsible",
   CHANGE_SEARCH_FILTER = "change_search_filter",
-  TOGGLE_LAST_30_DAYS = "toggle_last_30_days"
+  TOGGLE_LAST_30_DAYS = "toggle_last_30_days",
 }
 
 interface FilterAction<T = keyof Filter> {
@@ -24,8 +24,7 @@ export function filterReducer(state: Filter, action: FilterAction): Filter {
       // Currently just a toggle between 30 days and null
       if (curValue === null) {
         newValue = 30
-      }
-      else {
+      } else {
         newValue = null
       }
 
@@ -43,17 +42,16 @@ export function filterReducer(state: Filter, action: FilterAction): Filter {
       return { ...state, collapseResponsible }
     }
     case FilterActionType.CHANGE_SEARCH_FILTER: {
-
       // Null check
-      if (action.payload === null)
-        return state
+      if (action.payload === null) return state
 
       // Non-null search filter values update filter state
       const newFilterValue: string = action.payload as string
       const newFilterState = {
-        ...state, [action.prop]: newFilterValue
+        ...state,
+        [action.prop]: newFilterValue,
       }
-      return newFilterState;
+      return newFilterState
     }
 
     default:


### PR DESCRIPTION
Har oppdatert repo-metrics webappen slik at alle filterinstillinger speiles i URL-en. Dette gjør at man kan sende hverandre lenker som bevarer tillstanden til appen. Dessuten litt refaktorering, all tillstand ligger i samme objekt nå bl.a