### PR TITLE
CDK aspect for overriding Lambda runtime

### DIFF
--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsedgeBA3B1DD0.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsedgeBA3B1DD0.template.json
@@ -70,7 +70,7 @@
         },
         "Description": "Nonce value: 2",
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",
@@ -197,7 +197,7 @@
         },
         "Description": "Nonce value: 2",
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",
@@ -324,7 +324,7 @@
         },
         "Description": "Nonce value: 2",
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",
@@ -451,7 +451,7 @@
         },
         "Description": "Nonce value: 2",
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",
@@ -578,7 +578,7 @@
         },
         "Description": "Nonce value: 2",
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -843,7 +843,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",
@@ -1193,7 +1193,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Tags": [
           {
             "Key": "Project",

--- a/packages/infrastructure/src/config.ts
+++ b/packages/infrastructure/src/config.ts
@@ -1,5 +1,6 @@
 import * as constructs from "constructs"
 import * as cdk from "aws-cdk-lib"
+import * as lambda from "aws-cdk-lib/aws-lambda"
 import { tagResources } from "@liflig/cdk"
 
 export const incubatorAccountId = "001112238813"
@@ -20,4 +21,18 @@ export function applyTags(scope: constructs.Construct) {
     Project: "repo-metrics",
     SourceRepo: "github/capralifecycle/liflig-repo-metrics",
   }))
+}
+
+export function overrideLambdaRuntime(scope: constructs.IConstruct) {
+  cdk.Aspects.of(scope).add({
+    visit(construct: constructs.IConstruct) {
+      if (
+        construct.node.defaultChild instanceof lambda.CfnFunction &&
+        (construct.node.scope?.node.id === "AuthLambdas" ||
+          construct.node.scope?.node.id.startsWith("henrist."))
+      ) {
+        construct.node.defaultChild.addPropertyOverride("Runtime", "nodejs16.x")
+      }
+    },
+  })
 }

--- a/packages/infrastructure/src/environment.ts
+++ b/packages/infrastructure/src/environment.ts
@@ -1,6 +1,6 @@
 import * as constructs from "constructs"
 import * as cdk from "aws-cdk-lib"
-import { applyTags, externalValues } from "./config"
+import { applyTags, externalValues, overrideLambdaRuntime } from "./config"
 import { RepoMetricsEdgeStack } from "./repo-metrics-edge-stack"
 import { RepoMetricsStack } from "./repo-metrics-stack"
 
@@ -9,6 +9,7 @@ export class RepoMetricsEnv extends cdk.Stage {
     super(scope, id, props)
 
     applyTags(this)
+    overrideLambdaRuntime(this)
 
     const edgeStack = new RepoMetricsEdgeStack(
       this,


### PR DESCRIPTION
Add a CDK aspect to override the Lambda runtime for various Lambda functions that are created by third-party CDK constructs.

We should wait a couple of days to see if the pull requests below are merged, as they bump the Node.js runtime in the third-party constructs themselves. The closer we get to Nov. 14, the Node.js 12 runtime deprecation date, we should consider either forking the projects below or use the CDK aspect introduced in this PR.

https://github.com/henrist/cdk-cloudfront-auth/pull/78
https://github.com/henrist/cdk-lambda-config/pull/41