### PR TITLE
Upgrade liflig-cdk for nodejs18 lambdas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/@liflig/cdk": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/@liflig/cdk/-/cdk-2.21.2.tgz",
-      "integrity": "sha512-AR63DDOoBOGKD6jh5wS1HP9IWmIpvCwFLXfokZC8cDKs4Ga9oU+ur9uWes5CFcBfEXWV+UQVQSSLUCPk78zheQ==",
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@liflig/cdk/-/cdk-2.21.3.tgz",
+      "integrity": "sha512-RsnMbAdLU5KdRteBlLAWh2MDRRxNe1eUCuHJ6OMXUhdS1jXq5HdaH11LxoXoG+1NIbkqXXmXKMNaiEw9peuyCg==",
       "dependencies": {
         "@capraconsulting/webapp-deploy-lambda": "2.2.0",
         "aws-sdk": "2.1629.0",
@@ -15211,7 +15211,7 @@
       "dependencies": {
         "@capraconsulting/webapp-deploy-lambda": "2.2.0",
         "@henrist/cdk-cloudfront-auth": "2.1.44",
-        "@liflig/cdk": "2.21.2",
+        "@liflig/cdk": "2.21.3",
         "aws-cdk-lib": "2.127.0",
         "constructs": "10.3.0"
       },

--- a/packages/infrastructure/__snapshots__/incub-repo-metrics-pipeline.template.json
+++ b/packages/infrastructure/__snapshots__/incub-repo-metrics-pipeline.template.json
@@ -120,7 +120,8 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "ZipFile": "exports.handler = async (event, context) => {\n    const AWS = require(\"aws-sdk\");\n    const s3 = new AWS.S3();\n    const codepipeline = new AWS.CodePipeline();\n    const jobId = event[\"CodePipeline.job\"].id;\n    try {\n        const userParametersRaw = event[\"CodePipeline.job\"].data.actionConfiguration.configuration\n            .UserParameters;\n        console.log(\"User parameters\", userParametersRaw);\n        const userParameters = JSON.parse(userParametersRaw);\n        const referenceData = await s3\n            .getObject({\n            Bucket: userParameters.bucketName,\n            Key: userParameters.objectKey,\n        })\n            .promise()\n            .then((it) => it.Body.toString());\n        const cloudAssemblyReference = JSON.parse(referenceData);\n        const outputArtifact = event[\"CodePipeline.job\"].data.outputArtifacts[0];\n        const s3Loc = outputArtifact.location.s3Location;\n        const cloudAssemblyZipData = await s3\n            .getObject({\n            Bucket: cloudAssemblyReference.cloudAssemblyBucketName,\n            Key: cloudAssemblyReference.cloudAssemblyBucketKey,\n        })\n            .promise();\n        console.log(\"Size of Cloud Assembly\", cloudAssemblyZipData.ContentLength);\n        await new AWS.S3({\n            credentials: event[\"CodePipeline.job\"].data.artifactCredentials,\n        })\n            .putObject({\n            Bucket: s3Loc.bucketName,\n            Key: s3Loc.objectKey,\n            Body: cloudAssemblyZipData.Body,\n        })\n            .promise();\n        await codepipeline\n            .putJobSuccessResult({\n            jobId,\n        })\n            .promise();\n        console.log(\"Success\");\n    }\n    catch (e) {\n        await codepipeline\n            .putJobFailureResult({\n            failureDetails: {\n                message: JSON.stringify(e),\n                type: \"JobFailed\",\n                externalExecutionId: context.awsRequestId,\n            },\n            jobId,\n        })\n            .promise();\n        console.error(\"Failed\", e);\n    }\n};"
+          "S3Bucket": "cdk-liflig-assets-001112238813-eu-west-1",
+          "S3Key": "snapshot-value.zip"
         },
         "Handler": "index.handler",
         "MemorySize": 512,
@@ -130,7 +131,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "Project",
@@ -152,7 +153,10 @@
         "PipelineCloudAssemblyLookupFnServiceRole2FDEF095"
       ],
       "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Pipeline/CloudAssemblyLookupFn/Resource"
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Pipeline/CloudAssemblyLookupFn/Resource",
+        "aws:asset:path": "asset.snapshot-value",
+        "aws:asset:is-bundled": true,
+        "aws:asset:property": "Code"
       }
     },
     "PipelineCodePipelineArtifactsBucketEncryptionKey0E77C3AE": {

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@capraconsulting/webapp-deploy-lambda": "2.2.0",
     "@henrist/cdk-cloudfront-auth": "2.1.44",
-    "@liflig/cdk": "2.21.2",
+    "@liflig/cdk": "2.21.3",
     "aws-cdk-lib": "2.127.0",
     "constructs": "10.3.0"
   }


### PR DESCRIPTION
Upgrades liflig-cdk library to a version using NodeJS 18 lambda runtimes instead of the soon-to-be-deprecated NodeJS 16 lambda runtimes.