### PR TITLE
Show created date for pull requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,10 @@
       "name": "root",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "dependencies": {
+        "date-fns": "3.6.0"
+      }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -7171,6 +7174,15 @@
       "integrity": "sha512-mpC1izx7lUSLYl4B88V2W57eNB4xS2ic+ahxK2AYUsaBTsCeHzT6K5ymUKzL9YPFf/GlygFqpiD4/NO1hxDsLw==",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/date-holidays": {

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "date-fns": "3.6.0"
+  }
 }

--- a/packages/webapp/src/PrColumnDetails.tsx
+++ b/packages/webapp/src/PrColumnDetails.tsx
@@ -1,5 +1,6 @@
 import { WebappMetricDataRepoDatapoint } from "@liflig/repo-metrics-repo-collector-types"
 import * as React from "react"
+import { formatDistance } from "date-fns"
 
 interface Props {
   prs: WebappMetricDataRepoDatapoint["github"]["prs"]
@@ -16,6 +17,8 @@ export const PrColumnDetails: React.FC<Props> = ({
     return <span style={{ color: "var(--color-success)" }}>Ingen</span>
   }
 
+  const now = new Date()
+
   return (
     <>
       <b>{prs.length}</b>
@@ -24,7 +27,11 @@ export const PrColumnDetails: React.FC<Props> = ({
           {prs.map((pr, idx) => (
             <li key={idx}>
               <a href={`${repoBaseUrl}/pull/${pr.number}`}>#{pr.number}</a>{" "}
-              {pr.title} ({pr.author})
+              {pr.title} ({pr.author},{" "}
+              {formatDistance(pr.createdAt, now, {
+                addSuffix: true,
+              })}
+              )
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Adds display of createdAt-info in the PR list using the date-fns library.

<img width="454" alt="image" src="https://github.com/user-attachments/assets/913fd68b-0fbc-4405-bd4d-27c71002724c">