### PR TITLE
cals-956: migrate to new snyk endpoint version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn-error.log
 outfile-collector.json
 outfile-aggregator.json
 tsconfig.tsbuildinfo
+.envrc

--- a/packages/repo-collector/src/snyk/service.ts
+++ b/packages/repo-collector/src/snyk/service.ts
@@ -36,9 +36,10 @@ export class SnykService {
     }
 
     let backportedProjects: SnykProject[] = []
-    const snykRestApiVersion = "2023-08-04"
 
-    let nextUrl: string | undefined = `/orgs/${encodeURIComponent(
+    const snykRestApiVersion = "2025-04-08"
+
+    let nextUrl: string | undefined = `/rest/orgs/${encodeURIComponent(
       snykAccountId,
     )}/projects?version=${snykRestApiVersion}&meta.latest_dependency_total=true&meta.latest_issue_counts=true&limit=100`
 
@@ -47,7 +48,7 @@ export class SnykService {
      * We continue calling the Snyk API and retrieving more projects until links.next is null
      * */
     while (nextUrl) {
-      const response = await fetch(`https://api.snyk.io/rest${nextUrl}`, {
+      const response = await fetch(`https://api.snyk.io${nextUrl}`, {
         method: "GET",
         headers: {
           Accept: "application/json",


### PR DESCRIPTION
## changes

- api version param: The [REST API docs](https://docs.snyk.io/snyk-api/rest-api/getting-started-with-the-rest-api) state that you should set version param to the current date
- nextUrl: in newer versions of the api, the "rest/" path fragment is returned by the response.links.next property, which is why this is now assumed to be a part of the nextUrl.

## testing

Tested locally:
- throwaway test TS test
- curl query
- repo-collector: npm run collect-locally

Verified that the collected Snyk repo stats correspond with actual values at Snyk web.