### PR TITLE
cals-1089 reduce aggregator lambda memory

### DIFF
--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2842,7 +2842,7 @@
         "Layers": [
           "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:38"
         ],
-        "MemorySize": 4000,
+        "MemorySize": 300,
         "Role": {
           "Fn::GetAtt": [
             "AggregatorServiceRole50457C61",

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -159,13 +159,14 @@ export class RepoMetricsStack extends cdk.Stack {
       alarmAction: corePlatform.slackWarningsAction,
     })
 
+    const aggregatorMemoryMB = 300
     const aggregator = new lambda.Function(this, "Aggregator", {
       code: lambda.Code.fromAsset("../repo-collector/dist"),
       handler: "index.aggregateHandler",
       runtime: lambda.Runtime.NODEJS_18_X,
       timeout: cdk.Duration.minutes(5),
       insightsVersion: lambda.LambdaInsightsVersion.VERSION_1_0_229_0,
-      memorySize: 4000,
+      memorySize: aggregatorMemoryMB,
       environment: {
         DATA_BUCKET_NAME: dataBucket.bucketName,
         WEBAPP_DATA_BUCKET_NAME: webappDataBucket.bucketName,


### PR DESCRIPTION
Snapshot read strategy has changed, and we no longer need all this
memory.

Last function invocation used 198 MB.
