### PR TITLE
convert lambda schedules to state machine

### DIFF
--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2234,434 +2234,6 @@
         "aws:asset:property": "Code"
       }
     },
-    "CollectorLogRetentionF9D3AFBE": {
-      "Type": "Custom::LogRetention",
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn"
-          ]
-        },
-        "LogGroupName": {
-          "Fn::Join": [
-            "",
-            [
-              "/aws/lambda/",
-              {
-                "Ref": "Collector9EBA7CF5"
-              }
-            ]
-          ]
-        }
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/Collector/LogRetention/Resource"
-      }
-    },
-    "CollectorCollectorLogGroupWarningMetricFilter3DCCB631": {
-      "Type": "AWS::Logs::MetricFilter",
-      "Properties": {
-        "FilterPattern": "WARN",
-        "LogGroupName": {
-          "Fn::GetAtt": [
-            "CollectorLogRetentionF9D3AFBE",
-            "LogGroupName"
-          ]
-        },
-        "MetricTransformations": [
-          {
-            "MetricName": "Warnings",
-            "MetricNamespace": {
-              "Fn::Join": [
-                "",
-                [
-                  "stack/incub-repo-metrics-main/",
-                  {
-                    "Ref": "Collector9EBA7CF5"
-                  },
-                  "/Warnings"
-                ]
-              ]
-            },
-            "MetricValue": "1"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/Collector/Collector-LogGroup/WarningMetricFilter/Resource"
-      }
-    },
-    "CollectorScheduleDC767626": {
-      "Type": "AWS::Events::Rule",
-      "Properties": {
-        "ScheduleExpression": "cron(0 0/6 * * ? *)",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "Collector9EBA7CF5",
-                "Arn"
-              ]
-            },
-            "Id": "Target0"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorSchedule/Resource"
-      }
-    },
-    "CollectorScheduleAllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainCollector5F0CF411366F0188": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "Collector9EBA7CF5",
-            "Arn"
-          ]
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "CollectorScheduleDC767626",
-            "Arn"
-          ]
-        }
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorSchedule/AllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainCollector5F0CF411"
-      }
-    },
-    "CollectorNotSuccessWarningCA9F6270": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              "Function ",
-              {
-                "Ref": "Collector9EBA7CF5"
-              },
-              " has not run successful for the last 12 hours"
-            ]
-          ]
-        },
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "invocations - errors",
-            "Id": "expr_1",
-            "ReturnData": true
-          },
-          {
-            "Id": "invocations",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Collector9EBA7CF5"
-                    }
-                  }
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 43200,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          },
-          {
-            "Id": "errors",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Collector9EBA7CF5"
-                    }
-                  }
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 43200,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          }
-        ],
-        "OKActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching"
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorNotSuccessWarning/Resource"
-      }
-    },
-    "CollectorNotSuccessAlarm73851829": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackalarmtopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              "Function ",
-              {
-                "Ref": "Collector9EBA7CF5"
-              },
-              " has not run successful for the last 1 day"
-            ]
-          ]
-        },
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "invocations - errors",
-            "Id": "expr_1",
-            "ReturnData": true
-          },
-          {
-            "Id": "invocations",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Collector9EBA7CF5"
-                    }
-                  }
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 86400,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          },
-          {
-            "Id": "errors",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Collector9EBA7CF5"
-                    }
-                  }
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 86400,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          }
-        ],
-        "OKActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackalarmtopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching"
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorNotSuccessAlarm/Resource"
-      }
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com"
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition"
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-              ]
-            ]
-          }
-        ],
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "repo-metrics"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-repo-metrics"
-          },
-          {
-            "Key": "StackName",
-            "Value": "incub-repo-metrics-main"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/Resource"
-      }
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": [
-          {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/DefaultPolicy/Resource"
-      }
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Handler": "index.handler",
-        "Runtime": "nodejs22.x",
-        "Timeout": 900,
-        "Code": {
-          "S3Bucket": "cdk-liflig-assets-001112238813-eu-west-1",
-          "S3Key": "snapshot-value.zip"
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn"
-          ]
-        },
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "repo-metrics"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-repo-metrics"
-          },
-          {
-            "Key": "StackName",
-            "Value": "incub-repo-metrics-main"
-          }
-        ]
-      },
-      "DependsOn": [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
-      ],
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Resource",
-        "aws:asset:path": "asset.snapshot-value",
-        "aws:asset:is-bundled": false,
-        "aws:asset:property": "Code"
-      }
-    },
-    "CollectorWarningAlarmA0B4423A": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "Collector9EBA7CF5"
-              },
-              " logged a warning."
-            ]
-          ]
-        },
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "MetricName": "Warnings",
-        "Namespace": {
-          "Fn::Join": [
-            "",
-            [
-              "stack/incub-repo-metrics-main/",
-              {
-                "Ref": "Collector9EBA7CF5"
-              },
-              "/Warnings"
-            ]
-          ]
-        },
-        "OKActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "Period": 60,
-        "Statistic": "Sum",
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching"
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorWarningAlarm/Resource"
-      }
-    },
     "AggregatorServiceRole50457C61": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -2879,211 +2451,6 @@
         "aws:asset:property": "Code"
       }
     },
-    "AggregatorSchedule80C87EEE": {
-      "Type": "AWS::Events::Rule",
-      "Properties": {
-        "ScheduleExpression": "cron(10 0/6 * * ? *)",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "Aggregator84F1B3DF",
-                "Arn"
-              ]
-            },
-            "Id": "Target0"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorSchedule/Resource"
-      }
-    },
-    "AggregatorScheduleAllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainAggregator0CC5D92026EEEE0C": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "Aggregator84F1B3DF",
-            "Arn"
-          ]
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "AggregatorSchedule80C87EEE",
-            "Arn"
-          ]
-        }
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorSchedule/AllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainAggregator0CC5D920"
-      }
-    },
-    "AggregatorNotSuccessWarning2CDA5617": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              "Function ",
-              {
-                "Ref": "Aggregator84F1B3DF"
-              },
-              " has not run successful for the last 12 hours"
-            ]
-          ]
-        },
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "invocations - errors",
-            "Id": "expr_1",
-            "ReturnData": true
-          },
-          {
-            "Id": "invocations",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Aggregator84F1B3DF"
-                    }
-                  }
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 43200,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          },
-          {
-            "Id": "errors",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Aggregator84F1B3DF"
-                    }
-                  }
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 43200,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          }
-        ],
-        "OKActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching"
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorNotSuccessWarning/Resource"
-      }
-    },
-    "AggregatorNotSuccessAlarm955602B9": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackalarmtopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              "Function ",
-              {
-                "Ref": "Aggregator84F1B3DF"
-              },
-              " has not run successful for the last 1 day"
-            ]
-          ]
-        },
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "invocations - errors",
-            "Id": "expr_1",
-            "ReturnData": true
-          },
-          {
-            "Id": "invocations",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Aggregator84F1B3DF"
-                    }
-                  }
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 86400,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          },
-          {
-            "Id": "errors",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Aggregator84F1B3DF"
-                    }
-                  }
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 86400,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          }
-        ],
-        "OKActions": [
-          {
-            "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackalarmtopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching"
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorNotSuccessAlarm/Resource"
-      }
-    },
     "ReporterServiceRole0C7A2B1F": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -3251,50 +2618,273 @@
         "aws:asset:property": "Code"
       }
     },
-    "ReporterSchedule65E61F50": {
-      "Type": "AWS::Events::Rule",
+    "StateMachineRoleB840431D": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "ScheduleExpression": "cron(0 7 * * ? *)",
-        "State": "ENABLED",
-        "Targets": [
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "states.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Tags": [
           {
-            "Arn": {
-              "Fn::GetAtt": [
-                "Reporter08098DAC",
-                "Arn"
-              ]
-            },
-            "Id": "Target0"
+            "Key": "Project",
+            "Value": "repo-metrics"
+          },
+          {
+            "Key": "SourceRepo",
+            "Value": "github/capralifecycle/liflig-repo-metrics"
+          },
+          {
+            "Key": "StackName",
+            "Value": "incub-repo-metrics-main"
           }
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/ReporterSchedule/Resource"
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/Role/Resource"
       }
     },
-    "ReporterScheduleAllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainReporter593FA6D5D56F3D22": {
-      "Type": "AWS::Lambda::Permission",
+    "StateMachineRoleDefaultPolicyDF1E6607": {
+      "Type": "AWS::IAM::Policy",
       "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "Collector9EBA7CF5",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "Collector9EBA7CF5",
+                          "Arn"
+                        ]
+                      },
+                      ":*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "Aggregator84F1B3DF",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "Aggregator84F1B3DF",
+                          "Arn"
+                        ]
+                      },
+                      ":*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "Reporter08098DAC",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "Reporter08098DAC",
+                          "Arn"
+                        ]
+                      },
+                      ":*"
+                    ]
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "StateMachineRoleDefaultPolicyDF1E6607",
+        "Roles": [
+          {
+            "Ref": "StateMachineRoleB840431D"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/Role/DefaultPolicy/Resource"
+      }
+    },
+    "StateMachine2E01A3A5": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{\"StartAt\":\"CollectorJob\",\"States\":{\"CollectorJob\":{\"Next\":\"AggregateJob\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"Resource\":\"arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+              {
+                "Fn::GetAtt": [
+                  "Collector9EBA7CF5",
+                  "Arn"
+                ]
+              },
+              "\",\"Payload.$\":\"$\"}},\"AggregateJob\":{\"Next\":\"ReportsJob\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"Resource\":\"arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+              {
+                "Fn::GetAtt": [
+                  "Aggregator84F1B3DF",
+                  "Arn"
+                ]
+              },
+              "\",\"Payload.$\":\"$\"}},\"ReportsJob\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"Resource\":\"arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+              {
+                "Fn::GetAtt": [
+                  "Reporter08098DAC",
+                  "Arn"
+                ]
+              },
+              "\",\"Payload.$\":\"$\"}}},\"TimeoutSeconds\":600}"
+            ]
+          ]
+        },
+        "RoleArn": {
           "Fn::GetAtt": [
-            "Reporter08098DAC",
+            "StateMachineRoleB840431D",
             "Arn"
           ]
         },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "ReporterSchedule65E61F50",
-            "Arn"
-          ]
-        }
+        "Tags": [
+          {
+            "Key": "Project",
+            "Value": "repo-metrics"
+          },
+          {
+            "Key": "SourceRepo",
+            "Value": "github/capralifecycle/liflig-repo-metrics"
+          },
+          {
+            "Key": "StackName",
+            "Value": "incub-repo-metrics-main"
+          }
+        ]
       },
+      "DependsOn": [
+        "StateMachineRoleDefaultPolicyDF1E6607",
+        "StateMachineRoleB840431D"
+      ],
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
       "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/ReporterSchedule/AllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainReporter593FA6D5"
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/Resource"
       }
     },
-    "ReporterNotSuccessAlarm26AEAE42": {
+    "StateMachineEventsRoleDBCDECD1": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Tags": [
+          {
+            "Key": "Project",
+            "Value": "repo-metrics"
+          },
+          {
+            "Key": "SourceRepo",
+            "Value": "github/capralifecycle/liflig-repo-metrics"
+          },
+          {
+            "Key": "StackName",
+            "Value": "incub-repo-metrics-main"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/EventsRole/Resource"
+      }
+    },
+    "StateMachineEventsRoleDefaultPolicyFB602CA9": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "StateMachine2E01A3A5"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "StateMachineEventsRoleDefaultPolicyFB602CA9",
+        "Roles": [
+          {
+            "Ref": "StateMachineEventsRoleDBCDECD1"
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/EventsRole/DefaultPolicy/Resource"
+      }
+    },
+    "StateMachineExecutionFailureAlarmAC371745": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmActions": [
@@ -3302,65 +2892,29 @@
             "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              "Function ",
-              {
-                "Ref": "Reporter08098DAC"
-              },
-              " has not run successful for the last 1 day"
-            ]
-          ]
-        },
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
           {
-            "Expression": "invocations - errors",
-            "Id": "expr_1",
+            "Id": "m1",
+            "Label": "Repo metrics state machine successes last 12 hours",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "StateMachineArn",
+                    "Value": {
+                      "Ref": "StateMachine2E01A3A5"
+                    }
+                  }
+                ],
+                "MetricName": "ExecutionsSucceeded",
+                "Namespace": "AWS/States"
+              },
+              "Period": 43200,
+              "Stat": "Sum"
+            },
             "ReturnData": true
-          },
-          {
-            "Id": "invocations",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Reporter08098DAC"
-                    }
-                  }
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 86400,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          },
-          {
-            "Id": "errors",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "Reporter08098DAC"
-                    }
-                  }
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda"
-              },
-              "Period": 86400,
-              "Stat": "Sum"
-            },
-            "ReturnData": false
           }
         ],
         "OKActions": [
@@ -3368,11 +2922,34 @@
             "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching"
+        "Threshold": 1
       },
       "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/ReporterNotSuccessAlarm/Resource"
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachineExecutionFailureAlarm/Resource"
+      }
+    },
+    "RepoMetricsSchedule10A365C7": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "cron(0 0/6 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "StateMachine2E01A3A5"
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineEventsRoleDBCDECD1",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/RepoMetricsSchedule/Resource"
       }
     }
   },
@@ -3420,10 +2997,6 @@
     "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/liflig-cdk/incub/platform/incubator-common-core/slack-warnings-topic-arn"
-    },
-    "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackalarmtopicarnC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Type": "AWS::SSM::Parameter::Value<String>",
-      "Default": "/liflig-cdk/incub/platform/incubator-common-core/slack-alarm-topic-arn"
     },
     "BootstrapVersion": {
       "Type": "AWS::SSM::Parameter::Value<String>",

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/manifest.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/manifest.json
@@ -648,78 +648,6 @@
             "data": "Collector9EBA7CF5"
           }
         ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/Collector/LogRetention/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorLogRetentionF9D3AFBE"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/Collector/Collector-LogGroup/WarningMetricFilter/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorCollectorLogGroupWarningMetricFilter3DCCB631"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorSchedule/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorScheduleDC767626"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorSchedule/AllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainCollector5F0CF411": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorScheduleAllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainCollector5F0CF411366F0188"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/SsmParameterValue:--liflig-cdk--incub--platform--incubator-common-core--slack-warnings-topic-arn:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorNotSuccessWarning/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorNotSuccessWarningCA9F6270"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/SsmParameterValue:--liflig-cdk--incub--platform--incubator-common-core--slack-alarm-topic-arn:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackalarmtopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorNotSuccessAlarm/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorNotSuccessAlarm73851829"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/DefaultPolicy/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/CollectorWarningAlarm/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "CollectorWarningAlarmA0B4423A"
-          }
-        ],
         "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/Aggregator/ServiceRole/Resource": [
           {
             "type": "aws:cdk:logicalId",
@@ -736,30 +664,6 @@
           {
             "type": "aws:cdk:logicalId",
             "data": "Aggregator84F1B3DF"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorSchedule/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AggregatorSchedule80C87EEE"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorSchedule/AllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainAggregator0CC5D920": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AggregatorScheduleAllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainAggregator0CC5D92026EEEE0C"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorNotSuccessWarning/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AggregatorNotSuccessWarning2CDA5617"
-          }
-        ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/AggregatorNotSuccessAlarm/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AggregatorNotSuccessAlarm955602B9"
           }
         ],
         "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/Reporter/ServiceRole/Resource": [
@@ -780,22 +684,52 @@
             "data": "Reporter08098DAC"
           }
         ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/ReporterSchedule/Resource": [
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/Role/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ReporterSchedule65E61F50"
+            "data": "StateMachineRoleB840431D"
           }
         ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/ReporterSchedule/AllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainReporter593FA6D5": [
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/Role/DefaultPolicy/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ReporterScheduleAllowEventRuleincubrepometricspipelineIncubatorincubrepometricsmainReporter593FA6D5D56F3D22"
+            "data": "StateMachineRoleDefaultPolicyDF1E6607"
           }
         ],
-        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/ReporterNotSuccessAlarm/Resource": [
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ReporterNotSuccessAlarm26AEAE42"
+            "data": "StateMachine2E01A3A5"
+          }
+        ],
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/EventsRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "StateMachineEventsRoleDBCDECD1"
+          }
+        ],
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachine/EventsRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "StateMachineEventsRoleDefaultPolicyFB602CA9"
+          }
+        ],
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/StateMachineExecutionFailureAlarm/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "StateMachineExecutionFailureAlarmAC371745"
+          }
+        ],
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/SsmParameterValue:--liflig-cdk--incub--platform--incubator-common-core--slack-warnings-topic-arn:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
+          }
+        ],
+        "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/RepoMetricsSchedule/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "RepoMetricsSchedule10A365C7"
           }
         ],
         "/incub-repo-metrics-pipeline/Incubator/incub-repo-metrics-main/DataBucketNameOutput": [

--- a/packages/infrastructure/__snapshots__/incub-repo-metrics-pipeline.template.json
+++ b/packages/infrastructure/__snapshots__/incub-repo-metrics-pipeline.template.json
@@ -870,32 +870,6 @@
                 },
                 "Configuration": {
                   "ProjectName": {
-                    "Ref": "PipelineCdkPipelineAssetsFileAsset13DA849FD2"
-                  }
-                },
-                "InputArtifacts": [
-                  {
-                    "Name": "Artifact_PrepareCloudAssembly_cloud-assembly-lookup"
-                  }
-                ],
-                "Name": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a_Code",
-                "RoleArn": {
-                  "Fn::GetAtt": [
-                    "PipelineCdkPipelineCodeBuildActionRole1C961342",
-                    "Arn"
-                  ]
-                },
-                "RunOrder": 1
-              },
-              {
-                "ActionTypeId": {
-                  "Category": "Build",
-                  "Owner": "AWS",
-                  "Provider": "CodeBuild",
-                  "Version": "1"
-                },
-                "Configuration": {
-                  "ProjectName": {
                     "Ref": "PipelineCdkPipelineAssetsFileAsset2207E4C42"
                   }
                 },
@@ -2078,20 +2052,6 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "PipelineCdkPipelineAssetsFileAsset13DA849FD2",
-                  "Arn"
-                ]
-              }
-            },
-            {
-              "Action": [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
                   "PipelineCdkPipelineAssetsFileAsset2207E4C42",
                   "Arn"
                 ]
@@ -2574,58 +2534,6 @@
       },
       "Metadata": {
         "aws:cdk:path": "incub-repo-metrics-pipeline/Pipeline/CdkPipeline/Assets/FileAsset12/Resource"
-      }
-    },
-    "PipelineCdkPipelineAssetsFileAsset13DA849FD2": {
-      "Type": "AWS::CodeBuild::Project",
-      "Properties": {
-        "Artifacts": {
-          "Type": "CODEPIPELINE"
-        },
-        "Cache": {
-          "Type": "NO_CACHE"
-        },
-        "Description": "Pipeline step incub-repo-metrics-pipeline/CodePipeline/Assets/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a_Code",
-        "EncryptionKey": {
-          "Fn::GetAtt": [
-            "PipelineCodePipelineArtifactsBucketEncryptionKey0E77C3AE",
-            "Arn"
-          ]
-        },
-        "Environment": {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:7.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER"
-        },
-        "ServiceRole": {
-          "Fn::GetAtt": [
-            "PipelineCdkPipelineAssetsFileRole0474FB57",
-            "Arn"
-          ]
-        },
-        "Source": {
-          "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"npm install -g cdk-assets@latest\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cdk-assets --path \\\"assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.assets.json\\\" --verbose publish \\\"snapshot-value:001112238813-eu-west-1\\\"\"\n      ]\n    }\n  }\n}",
-          "Type": "CODEPIPELINE"
-        },
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "repo-metrics"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-repo-metrics"
-          },
-          {
-            "Key": "StackName",
-            "Value": "incub-repo-metrics-pipeline"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "incub-repo-metrics-pipeline/Pipeline/CdkPipeline/Assets/FileAsset13/Resource"
       }
     },
     "PipelineCdkPipelineAssetsFileAsset2207E4C42": {

--- a/packages/infrastructure/__snapshots__/manifest.json
+++ b/packages/infrastructure/__snapshots__/manifest.json
@@ -245,12 +245,6 @@
             "data": "PipelineCdkPipelineAssetsFileAsset129D5593A4"
           }
         ],
-        "/incub-repo-metrics-pipeline/Pipeline/CdkPipeline/Assets/FileAsset13/Resource": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "PipelineCdkPipelineAssetsFileAsset13DA849FD2"
-          }
-        ],
         "/incub-repo-metrics-pipeline/Pipeline/CdkPipeline/Assets/FileAsset2/Resource": [
           {
             "type": "aws:cdk:logicalId",


### PR DESCRIPTION
Combines lambda functions into a state machine that runs every 6 hours.

Based on initial work in https://github.com/capralifecycle/liflig-repo-metrics/pull/124 with the following changes:
- Route alarms to Slack warnings, rather than alarms
- Retain v18 lambda runtimes
- Retain SonarCloud support
- Migrate from deprecated Statistics construct