### PR TITLE
fix: remove reference to obsolete action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           node-version: 22.21.0
 
-      - uses: capralifecycle/actions-lib/configure-npm@b4bb65b0ab41499f4829fe99c4b33b0b5a363562 # v1.6.2
-
       - uses: capralifecycle/actions-lib/configure-aws-credentials@b4bb65b0ab41499f4829fe99c4b33b0b5a363562 # v1.6.2
         id: aws
         with:


### PR DESCRIPTION
The configure-npm action is deprecated and will soon be archived.
