### PR TITLE
fix(deps): update axios to v1.15.0 [security]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@liflig/repo-metrics-repo-collector-types": "0.0.0-development",
         "@octokit/rest": "^22.0.1",
         "ajv": "8.18.0",
-        "axios": "1.14.0",
+        "axios": "1.15.0",
         "date-holidays": "3.26.12",
         "js-yaml": "4.1.1",
         "lodash-es": "4.18.1",
@@ -567,7 +567,7 @@
 
     "aws-jwt-verify": ["aws-jwt-verify@5.1.1", "", {}, "sha512-j6whGdGJmQ27agk4ijY8RPv6itb8JLb7SCJ86fEnneTcSBrpxuwL8kLq6y5WVH95aIknyAloEqAsaOLS1J8ITQ=="],
 
-    "axios": ["axios@1.14.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ=="],
+    "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,4 +6,6 @@ minimumReleaseAgeExcludes = [
   "@liflig/cdk-cloudfront-auth",
   "@liflig/load-secrets",
   "@liflig/repo-metrics-repo-collector-types",
+  # Temporary: critical SSRF fix in 1.15.0, remove once it clears the 3-day window (after 11. april 2026)
+  "axios",
 ]

--- a/packages/repo-collector/package.json
+++ b/packages/repo-collector/package.json
@@ -29,7 +29,7 @@
     "@liflig/repo-metrics-repo-collector-types": "0.0.0-development",
     "@octokit/rest": "^22.0.1",
     "ajv": "8.18.0",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "date-holidays": "3.26.12",
     "js-yaml": "4.1.1",
     "lodash-es": "4.18.1",


### PR DESCRIPTION
## Summary
- Updates axios from 1.14.0 to 1.15.0 to fix critical SSRF vulnerability ([GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5))
- Temporarily adds axios to `bunfig.toml` release-age excludes (1.15.0 is <3 days old) — remove after April 11