### PR TITLE
fix: use workspace protocol for repo-collector-types dependency

### DIFF
--- a/packages/repo-collector/package.json
+++ b/packages/repo-collector/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@js-temporal/polyfill": "0.5.1",
-    "@liflig/repo-metrics-repo-collector-types": "0.0.0-development",
+    "@liflig/repo-metrics-repo-collector-types": "workspace:*",
     "@octokit/rest": "^22.0.1",
     "ajv": "8.18.0",
     "axios": "1.15.0",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -8,7 +8,7 @@
     "build": "vite build --mode production"
   },
   "devDependencies": {
-    "@liflig/repo-metrics-repo-collector-types": "0.0.0-development",
+    "@liflig/repo-metrics-repo-collector-types": "workspace:*",
     "@types/lodash-es": "4.17.12",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",


### PR DESCRIPTION
## Summary

- Replace the placeholder version `0.0.0-development` for `@liflig/repo-metrics-repo-collector-types` with the `workspace:*` protocol in `packages/repo-collector` and `packages/webapp`.
- Resolves the Renovate warning: `Failed to look up npm package @liflig/repo-metrics-repo-collector-types: no-result`. The package is internal to this monorepo and not published to npm, so it should be referenced via the workspace protocol.