### PR TITLE
feat(collector): discover GitHub App installation ID at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,15 @@ Open local server at: <http://localhost:3000>
 
 GitHub authentication uses a GitHub App (server-to-server auth with installation tokens), not a personal access token. The App is registered in the `capralifecycle` org and installed on the repos it should read.
 
-Credentials live in two AWS Secrets Manager secrets (region `eu-west-1`, account `liflig-incubator`):
+Credentials live in a single AWS Secrets Manager secret (region `eu-west-1`, account `liflig-incubator`):
 
 - `/incub/repo-metrics/github-app` — JSON `{ appId, privateKey }` — the App identity, shared across all installations.
-- `/incub/repo-metrics/github-app-install-capralifecycle` — plain string containing the installation ID for the `capralifecycle` org.
 
-The Lambda reads these at runtime via its IAM role. Locally, the collector reads them via your AWS profile — no PAT or env var is involved for GitHub.
+The target organisation is provided via the `GITHUB_APP_ORG` environment variable (Lambda: set by the CDK stack; CLI: defaults to `capralifecycle`). At startup the collector looks up the installation for that org via `GET /orgs/{org}/installation` using an App JWT signed with the private key, and uses the returned installation ID for all subsequent API calls. Adding or reinstalling the App on the org does not require any secret change — the next run discovers the new installation ID automatically.
 
-To populate the two secrets for the first time (or to update any non-PEM field), run:
+The Lambda reads the secret at runtime via its IAM role. Locally, the collector reads it via your AWS profile — no PAT or env var is involved for GitHub auth itself.
+
+To populate `appId` (for first-time setup or after re-registering the App), run:
 
 ```shell
 cd packages/infrastructure
@@ -161,7 +162,7 @@ The App's private key is a long-lived credential that can mint tokens for every 
    ```
    This reads the existing secret JSON, replaces only the `privateKey` field, and writes it back to Secrets Manager
 3. **Verify.**
-   Redeploy (or wait for the next scheduled collector run) and check CloudWatch logs for the `[github-auth] using GitHub App installation (appId=…, installationId=…)` line and a successful snapshot write.
+   Redeploy (or wait for the next scheduled collector run) and check CloudWatch logs for the `[github-auth] using GitHub App installation (appId=…, org=…, installationId=…)` line and a successful snapshot write.
 4. **Revoke the old key.**
    Back in the App's "Private keys" settings, delete the old key.
 5. **Delete the local PEM.**

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2084,25 +2084,6 @@
                     {
                       "Ref": "AWS::Partition"
                     },
-                    ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/github-app-install-capralifecycle-??????"
-                  ]
-                ]
-              }
-            },
-            {
-              "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition"
-                    },
                     ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/snyk-token-??????"
                   ]
                 ]
@@ -2199,18 +2180,7 @@
                 ]
               ]
             },
-            "GITHUB_APP_INSTALL_SECRET_ID": {
-              "Fn::Join": [
-                "",
-                [
-                  "arn:",
-                  {
-                    "Ref": "AWS::Partition"
-                  },
-                  ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/github-app-install-capralifecycle"
-                ]
-              ]
-            },
+            "GITHUB_APP_ORG": "capralifecycle",
             "SNYK_TOKEN_SECRET_ID": {
               "Fn::Join": [
                 "",

--- a/packages/infrastructure/load-secrets.ts
+++ b/packages/infrastructure/load-secrets.ts
@@ -23,12 +23,6 @@ const githubAppSecret: loadSecrets.Secret = {
   ],
 }
 
-const githubAppInstallCapralifecycleSecret: loadSecrets.Secret = {
-  name: "github-app-install-capralifecycle",
-  description: "GitHub App installation ID for the capralifecycle org",
-  type: "string",
-}
-
 const snykTokenSecret: loadSecrets.Secret = {
   name: "snyk-token",
   description: "Snyk token",
@@ -71,7 +65,6 @@ loadSecrets.loadSecretsCli({
       namePrefix: "/incub/repo-metrics/",
       secrets: [
         githubAppSecret,
-        githubAppInstallCapralifecycleSecret,
         snykTokenSecret,
         reporterSlackWebhookUrlSecret,
         slackPipelineNotificationWebhookUrl,

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -104,13 +104,6 @@ export class RepoMetricsStack extends cdk.Stack {
       "/incub/repo-metrics/github-app",
     )
 
-    const githubAppInstallCapralifecycleSecret =
-      secretsmanager.Secret.fromSecretNameV2(
-        this,
-        "GithubAppInstallCapralifecycleSecret",
-        "/incub/repo-metrics/github-app-install-capralifecycle",
-      )
-
     const snykTokenSecret = secretsmanager.Secret.fromSecretNameV2(
       this,
       "SnykTokenSecret",
@@ -131,8 +124,7 @@ export class RepoMetricsStack extends cdk.Stack {
       memorySize: 256,
       environment: {
         GITHUB_APP_SECRET_ID: githubAppSecret.secretArn,
-        GITHUB_APP_INSTALL_SECRET_ID:
-          githubAppInstallCapralifecycleSecret.secretArn,
+        GITHUB_APP_ORG: "capralifecycle",
         SNYK_TOKEN_SECRET_ID: snykTokenSecret.secretArn,
         SONARCLOUD_TOKEN_SECRET_ID: sonarCloudTokenSecret.secretArn,
         DATA_BUCKET_NAME: dataBucket.bucketName,
@@ -142,7 +134,6 @@ export class RepoMetricsStack extends cdk.Stack {
     })
 
     githubAppSecret.grantRead(collectorFn)
-    githubAppInstallCapralifecycleSecret.grantRead(collectorFn)
     snykTokenSecret.grantRead(collectorFn)
     sonarCloudTokenSecret.grantRead(collectorFn)
     dataBucket.grantReadWrite(collectorFn)

--- a/packages/repo-collector/src/github/token.ts
+++ b/packages/repo-collector/src/github/token.ts
@@ -1,6 +1,7 @@
 import * as process from "node:process"
 import { SecretsManager } from "@aws-sdk/client-secrets-manager"
 import { createAppAuth } from "@octokit/auth-app"
+import { Octokit } from "@octokit/rest"
 
 type OctokitAuthOptions = {
   authStrategy: typeof createAppAuth
@@ -21,6 +22,7 @@ interface AppCredentials {
   appId: string
   privateKey: string
   installationId: number
+  orgName: string
 }
 
 export class GitHubAppProvider implements GitHubAuthProvider {
@@ -33,7 +35,7 @@ export class GitHubAppProvider implements GitHubAuthProvider {
       installationId: creds.installationId,
     })
     console.log(
-      `[github-auth] using GitHub App installation (appId=${creds.appId}, installationId=${creds.installationId})`,
+      `[github-auth] using GitHub App installation (appId=${creds.appId}, org=${creds.orgName}, installationId=${creds.installationId})`,
     )
   }
 
@@ -59,29 +61,21 @@ export class GitHubAppProvider implements GitHubAuthProvider {
 }
 
 const DEFAULT_APP_SECRET_ID = "/incub/repo-metrics/github-app"
-const DEFAULT_INSTALL_SECRET_ID =
-  "/incub/repo-metrics/github-app-install-capralifecycle"
+const DEFAULT_ORG_NAME = "capralifecycle"
 
 export async function loadGitHubAppProviderFromSecrets(opts?: {
   appSecretId?: string
-  installSecretId?: string
+  orgName?: string
 }): Promise<GitHubAppProvider> {
   const appSecretId =
     opts?.appSecretId ??
     process.env.GITHUB_APP_SECRET_ID ??
     DEFAULT_APP_SECRET_ID
-  const installSecretId =
-    opts?.installSecretId ??
-    process.env.GITHUB_APP_INSTALL_SECRET_ID ??
-    DEFAULT_INSTALL_SECRET_ID
+  const orgName =
+    opts?.orgName ?? process.env.GITHUB_APP_ORG ?? DEFAULT_ORG_NAME
 
   const client = new SecretsManager({})
-
-  const [appSecret, installationIdRaw] = await Promise.all([
-    readJsonSecret(client, appSecretId),
-    readStringSecret(client, installSecretId),
-  ])
-
+  const appSecret = await readJsonSecret(client, appSecretId)
   const { appId, privateKey } = appSecret
 
   if (!appId) {
@@ -90,33 +84,52 @@ export async function loadGitHubAppProviderFromSecrets(opts?: {
   if (!privateKey) {
     throw new Error(`Missing "privateKey" field in secret ${appSecretId}`)
   }
-  const installationId = Number(installationIdRaw)
-  if (!Number.isFinite(installationId)) {
-    throw new Error(
-      `Secret ${installSecretId} is not a number: ${installationIdRaw}`,
-    )
-  }
 
-  return new GitHubAppProvider({ appId, privateKey, installationId })
+  const installationId = await discoverInstallationId({
+    appId,
+    privateKey,
+    orgName,
+  })
+
+  return new GitHubAppProvider({ appId, privateKey, installationId, orgName })
 }
 
-async function readStringSecret(
-  client: SecretsManager,
-  secretId: string,
-): Promise<string> {
-  const result = await client.getSecretValue({ SecretId: secretId })
-  if (result.SecretString == null) {
-    throw new Error(`Secret ${secretId} has no SecretString`)
+async function discoverInstallationId(args: {
+  appId: string
+  privateKey: string
+  orgName: string
+}): Promise<number> {
+  const appOctokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      appId: args.appId,
+      privateKey: args.privateKey,
+    },
+  })
+
+  try {
+    const { data } = await appOctokit.request("GET /orgs/{org}/installation", {
+      org: args.orgName,
+    })
+    return data.id
+  } catch (err) {
+    const status = (err as { status?: number }).status
+    if (status === 404) {
+      throw new Error(
+        `GitHub App is not installed on org "${args.orgName}". Install the App on the org and retry.`,
+      )
+    }
+    throw err
   }
-  return result.SecretString
 }
 
 async function readJsonSecret(
   client: SecretsManager,
   secretId: string,
 ): Promise<Record<string, string>> {
-  return JSON.parse(await readStringSecret(client, secretId)) as Record<
-    string,
-    string
-  >
+  const result = await client.getSecretValue({ SecretId: secretId })
+  if (result.SecretString == null) {
+    throw new Error(`Secret ${secretId} has no SecretString`)
+  }
+  return JSON.parse(result.SecretString) as Record<string, string>
 }


### PR DESCRIPTION
## Main change

The collector now discovers the installation ID at startup via `GET /orgs/{org}/installation` (authed with an App JWT), instead of reading it from a dedicated per-org secret.

Target org comes from `GITHUB_APP_ORG` (set by the CDK stack for Lambda; defaults to `capralifecycle` locally). One fewer secret to manage, and reinstalling the App no longer requires a secret update — the next run picks up the new installation ID automatically.

### Post-deploy

`/incub/repo-metrics/github-app-install-capralifecycle` is orphaned after this ships and can be deleted from Secrets Manager.

### Verification

Generated snapshots on both `master` (stored-ID path) and this branch (discovery path) with the same AWS creds — byte-identical except for timestamp. The startup log line now reads `[github-auth] using GitHub App installation (appId=…, org=…, installationId=…)`.

## Also in this PR

- `chore(infra): update CDK snapshots for installation discovery` — mechanical.