### PR TITLE
fix(webapp): stop column reflow when expanding repo rows

### DIFF
--- a/packages/webapp/src/Repo.tsx
+++ b/packages/webapp/src/Repo.tsx
@@ -34,6 +34,7 @@ export const repoColumns = (props: {
     {
       header: "Repo",
       headerIcon: <GitHubIcon />,
+      width: "18%",
       sortOn: (repo) => {
         return repo.name.toLowerCase()
       },
@@ -52,6 +53,7 @@ export const repoColumns = (props: {
       header: "Avhengigheter",
       subheader: "Renovate",
       headerIcon: <RenovateIcon />,
+      width: "22%",
       sortOn: (repo) =>
         repo.metrics.github.availableUpdates
           ?.flatMap((category) =>
@@ -138,6 +140,7 @@ export const repoColumns = (props: {
     {
       header: "PRs",
       headerIcon: <PrIcon />,
+      width: "22%",
       sortOn: (repo) =>
         repo.metrics.github.prs.filter((it) => !isBotPr(it)).length,
       render: (repo, isExpanded) => {
@@ -154,6 +157,7 @@ export const repoColumns = (props: {
     {
       header: "Bot PR",
       headerIcon: <PrIcon />,
+      width: "18%",
       sortOn: (repo) =>
         repo.metrics.github.prs.filter((it) => isBotPr(it)).length,
       render: (repo, isExpanded) => {
@@ -171,6 +175,7 @@ export const repoColumns = (props: {
       header: "Sårbarheter",
       subheader: "GitHub",
       headerIcon: <SecurityIcon />,
+      width: "9%",
       sortOn: (repo) => repo.metrics.github.vulnerabilityAlerts.length,
       render: (repo, isExpanded) => {
         const githubVulAlerts = repo.metrics.github.vulnerabilityAlerts
@@ -219,6 +224,7 @@ export const repoColumns = (props: {
       subheader: "Snyk (C/H/M/L)",
       subheaderTitle: "Critical / High / Medium / Low",
       headerIcon: <SnykIcon />,
+      width: "7%",
       sortOn: (repo) => repo.metrics.snyk?.totalIssues,
       render: (repo, isExpanded) => {
         const snyk = repo.metrics.snyk
@@ -265,6 +271,7 @@ export const repoColumns = (props: {
       header: "Testdekning",
       subheader: "SonarCloud",
       headerIcon: <SonarCloudIcon />,
+      width: "4%",
       sortOn: (repo) =>
         repo.metrics.sonarCloud.testCoverage
           ? Number(repo.metrics.sonarCloud.testCoverage)

--- a/packages/webapp/src/Table.tsx
+++ b/packages/webapp/src/Table.tsx
@@ -5,6 +5,7 @@ export interface Column<T> {
   headerIcon?: React.ReactNode
   subheader?: string
   subheaderTitle?: string
+  width?: string
   render: (value: T, isExpanded: boolean) => React.ReactNode
   sortOn?: (value: T) => string | number | undefined
 }
@@ -89,13 +90,14 @@ function Table<T extends object>({ columns, data, rowKey }: Props<T>) {
       : [...data].sort(compareValues(valueMapperForSorting, sortState.sortAsc))
 
   return (
-    <table style={{ width: "100%" }}>
+    <table style={{ width: "100%", tableLayout: "fixed" }}>
       <thead>
         <tr>
           {rowKey && <th className="expand-col" />}
           {columns.map((it) => (
             <th
               key={columnKey(it)}
+              style={it.width ? { width: it.width } : undefined}
               onClick={() =>
                 it.sortOn ? toggleSortState(columnKey(it)) : undefined
               }


### PR DESCRIPTION
Use table-layout: fixed with explicit per-column widths so that
expanding a row's PR/dep list no longer redistributes column widths
and re-wraps rows above the clicked one.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


Video showing the current problem:
https://github.com/user-attachments/assets/aa8d83a2-cb7a-4ed7-a59e-d8ffa90f18d4


