### PR TITLE
feat: run repo metrics collection every hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ subgraph Repo Metrics
     SonarCloud
   end
 
-  subgraph "Data Processing (state machine, runs every 6h)"
+  subgraph "Data Processing (state machine, runs hourly)"
     subgraph Collection
       collector(Lambda: Collector)
       secrets(Secrets Manager)

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2992,13 +2992,13 @@
             "Ref": "SsmParameterValuelifligcdkincubplatformincubatorcommoncoreslackwarningstopicarnC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
-        "AlarmDescription": "Enter alarm state when state machine has not succeeded in the last 12 hours.",
+        "AlarmDescription": "Enter alarm state when state machine has not succeeded in the last 6 hours.",
         "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Id": "m1",
-            "Label": "Repo metrics state machine successes last 12 hours",
+            "Label": "Repo metrics state machine successes last 6 hours",
             "MetricStat": {
               "Metric": {
                 "Dimensions": [
@@ -3012,7 +3012,7 @@
                 "MetricName": "ExecutionsSucceeded",
                 "Namespace": "AWS/States"
               },
-              "Period": 43200,
+              "Period": 21600,
               "Stat": "Sum"
             },
             "ReturnData": true
@@ -3032,7 +3032,7 @@
     "RepoMetricsSchedule10A365C7": {
       "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "cron(0 0/6 * * ? *)",
+        "ScheduleExpression": "cron(0 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -217,19 +217,19 @@ export class RepoMetricsStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(10),
     })
 
-    const executionSuccessesLast12Hours = stateMachine.metricSucceeded({
+    const executionSuccessesLast6Hours = stateMachine.metricSucceeded({
       statistic: cw.Stats.SUM,
-      period: Duration.hours(12),
-      label: "Repo metrics state machine successes last 12 hours",
+      period: Duration.hours(6),
+      label: "Repo metrics state machine successes last 6 hours",
     })
 
     const alarm = new cw.Alarm(this, "StateMachineExecutionFailureAlarm", {
       alarmDescription:
-        "Enter alarm state when state machine has not succeeded in the last 12 hours.",
+        "Enter alarm state when state machine has not succeeded in the last 6 hours.",
       comparisonOperator: cw.ComparisonOperator.LESS_THAN_THRESHOLD,
       threshold: 1,
       evaluationPeriods: 1,
-      metric: executionSuccessesLast12Hours,
+      metric: executionSuccessesLast6Hours,
     })
 
     alarm.addAlarmAction(corePlatform.slackWarningsAction)
@@ -238,7 +238,6 @@ export class RepoMetricsStack extends cdk.Stack {
     // State machine schedule
     new events.Rule(this, "RepoMetricsSchedule", {
       schedule: events.Schedule.cron({
-        hour: "0/6",
         minute: "0",
       }),
       targets: [new eventstargets.SfnStateMachine(stateMachine)],

--- a/packages/repo-collector/README.md
+++ b/packages/repo-collector/README.md
@@ -7,8 +7,7 @@ This package produces 3 lambdas:
    It also invalidates the CloudFront distribution for the data read by the frontend.
 3. A reporter that notifies slack with Repo-Metrics data
 
-The lambdas are scheduled to run sequentially by EventBridge Cron jobs with offsets.  
-Collector runs every 6th hour, then Aggregator 10 minutes past every 6th hour, and reporter every 7th hour.  
+The collector and aggregator run sequentially in a Step Functions state machine triggered hourly by EventBridge. The reporter is triggered separately at 07:00 UTC daily.  
 (This is configured in the [infra stack](../infrastructure/src/repo-metrics-stack.ts).)
 
 ## Tokens and Permissions


### PR DESCRIPTION
## Summary
- Change Step Functions schedule from every 6 hours to hourly