### PR TITLE
feat(reporter): per-team Slack messages with severity-grouped sections

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,6 +159,7 @@ tasks:
 
   lambdas.report-locally:
     dir: "{{.lambdas}}"
+    interactive: true
     cmd: bun run report-locally
 
   lambdas.serve-local-data:

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "@aws-sdk/client-s3": "3.1047.0",
         "@aws-sdk/client-secrets-manager": "3.1047.0",
         "@octokit/types": "16.0.0",
+        "@slack/types": "2.21.1",
         "@types/aws-lambda": "8.10.161",
         "@types/bun": "^1.3.10",
         "@types/js-yaml": "4.0.9",
@@ -365,6 +366,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0", "", {}, "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ=="],
+
+    "@slack/types": ["@slack/types@2.21.1", "", {}, "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="],
 
     "@smithy/core": ["@smithy/core@3.24.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog=="],
 

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2592,6 +2592,20 @@
                 ]
               ]
             },
+            "WEBAPP_URL": {
+              "Fn::Join": [
+                "",
+                [
+                  "https://",
+                  {
+                    "Fn::GetAtt": [
+                      "Distribution830FAC52",
+                      "DomainName"
+                    ]
+                  }
+                ]
+              ]
+            },
             "SERIAL": "0"
           }
         },

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -174,6 +174,7 @@ export class RepoMetricsStack extends cdk.Stack {
         SLACK_WEBHOOK_URL: reporterSlackWebhookUrlSecret
           .secretValueFromJson("url")
           .toString(),
+        WEBAPP_URL: `https://${distribution.distributionDomainName}`,
         // Used to update the lambda configuration when the secret value is updated
         // in Secrets Manager
         SERIAL: "0",

--- a/packages/repo-collector/package.json
+++ b/packages/repo-collector/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-s3": "3.1047.0",
     "@aws-sdk/client-secrets-manager": "3.1047.0",
     "@octokit/types": "16.0.0",
+    "@slack/types": "2.21.1",
     "@types/aws-lambda": "8.10.161",
     "@types/bun": "^1.3.10",
     "@types/js-yaml": "4.0.9",

--- a/packages/repo-collector/src/lambda.ts
+++ b/packages/repo-collector/src/lambda.ts
@@ -4,9 +4,9 @@ import type { Handler } from "aws-lambda"
 import { isWorkingDay } from "./dates"
 import { loadGitHubAppProviderFromSecrets } from "./github/token"
 import {
-  formatReportData,
-  generateMessage,
-  sendSlackMessage,
+  buildPerTeamMessages,
+  buildReportData,
+  sendSlackMessages,
 } from "./reporter/reporter"
 import { collect } from "./snapshots/collect"
 import { S3SnapshotsRepository } from "./snapshots/snapshots-repository"
@@ -127,17 +127,12 @@ export const reportHandler: Handler = async () => {
 
   const dataBucketName = requireEnv("DATA_BUCKET_NAME")
   const slackWebhookUrl = requireEnv("SLACK_WEBHOOK_URL")
+  const webappUrl = requireEnv("WEBAPP_URL")
 
   const snapshotsRepository = new S3SnapshotsRepository(dataBucketName)
 
   const snapshotData = await snapshotsRepository.get()
-  const details = await formatReportData(snapshotData)
-
-  if (details == null) {
-    console.log("No data found to generate details")
-    return
-  }
-
-  const message = generateMessage(details)
-  await sendSlackMessage(slackWebhookUrl, message)
+  const reportData = buildReportData(snapshotData, Temporal.Now.instant())
+  const messages = buildPerTeamMessages(reportData, webappUrl)
+  await sendSlackMessages(slackWebhookUrl, messages)
 }

--- a/packages/repo-collector/src/report-locally.ts
+++ b/packages/repo-collector/src/report-locally.ts
@@ -1,29 +1,42 @@
+import { Temporal } from "@js-temporal/polyfill"
 import {
-  formatReportData,
-  generateMessage,
-  sendSlackMessage,
+  buildPerTeamMessages,
+  buildReportData,
+  sendSlackMessages,
 } from "./reporter/reporter"
 import { LocalSnapshotsRepository } from "./snapshots/snapshots-repository"
 
 async function main() {
   const snapshotsRepository = new LocalSnapshotsRepository()
+  const webappUrl =
+    process.env.WEBAPP_URL ?? "https://d2799m9v6pw1zy.cloudfront.net"
 
   const snapshotData = await snapshotsRepository.get()
-  const details = await formatReportData(snapshotData)
+  const reportData = buildReportData(snapshotData, Temporal.Now.instant())
+  const messages = buildPerTeamMessages(reportData, webappUrl)
 
-  if (details == null) {
-    console.log("No data found to generate details")
-    return
+  console.log(
+    `Will send ${messages.length} message(s) — one per team with vulnerabilities.`,
+  )
+  console.log(
+    "Paste any single block payload into https://app.slack.com/block-kit-builder/ to preview.",
+  )
+  console.log(
+    "(Builder validates against a blocks-only schema; the top-level `text`",
+  )
+  console.log(
+    " field used for webhook notification fallback is omitted here.)\n",
+  )
+  for (const [i, message] of messages.entries()) {
+    console.log(`# Message ${i + 1}: ${message.text}`)
+    console.log(JSON.stringify({ blocks: message.blocks }, null, 2))
+    console.log()
   }
-
-  const message = generateMessage(details)
-
-  console.log(message)
 
   const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL
   if (slackWebhookUrl) {
-    console.log("Got Slack webhook URL - will send")
-    await sendSlackMessage(slackWebhookUrl, message)
+    console.log(`Sending ${messages.length} message(s) to Slack…`)
+    await sendSlackMessages(slackWebhookUrl, messages)
   }
 }
 

--- a/packages/repo-collector/src/reporter/reporter.test.ts
+++ b/packages/repo-collector/src/reporter/reporter.test.ts
@@ -1,24 +1,357 @@
 import { Temporal } from "@js-temporal/polyfill"
-import { expect, test } from "vitest"
-import { calculateCutoffTimestamp } from "./reporter"
+import type {
+  SnapshotData,
+  SnapshotMetrics,
+} from "@liflig/repo-metrics-repo-collector-types"
+import { describe, expect, test } from "vitest"
+import {
+  buildPerTeamMessages,
+  buildReportData,
+  countSeveritiesForRepo,
+  findOldPrs,
+} from "./reporter"
 
-test("cutoff on wednesday in normal week", () => {
-  const wednesday = Temporal.Instant.from("2021-03-03T04:30:22.123Z")
-  const cutoff = calculateCutoffTimestamp(wednesday)
+const now = Temporal.Instant.from("2026-05-18T07:00:00Z")
 
-  expect(cutoff).toStrictEqual(Temporal.Instant.from("2021-03-02T06:30:00Z"))
+function repo(overrides: Partial<SnapshotMetrics> = {}): SnapshotMetrics {
+  return {
+    version: "1.2",
+    repoId: "org/repo",
+    responsible: "team-a",
+    github: {
+      orgName: "org",
+      repoName: "repo",
+      prs: [],
+      vulnerabilityAlerts: [],
+      renovateDependencyDashboardIssue: null,
+    },
+    snyk: { projects: [] },
+    ...overrides,
+  }
+}
+
+type SeverityInput = {
+  critical?: number
+  high: number
+  medium: number
+  low: number
+}
+
+function snykProject(
+  issueCountsBySeverity: SeverityInput,
+): SnapshotMetrics["snyk"]["projects"][number] {
+  return {
+    name: "p",
+    id: "1",
+    created: "",
+    origin: "",
+    type: "",
+    testFrequency: "",
+    totalDependencies: 0,
+    browseUrl: "",
+    issueCountsBySeverity,
+  }
+}
+
+function repoWithSnyk(
+  overrides: Partial<SnapshotMetrics> & { severities: SeverityInput },
+): SnapshotMetrics {
+  const { severities, ...rest } = overrides
+  return repo({ ...rest, snyk: { projects: [snykProject(severities)] } })
+}
+
+describe("countSeveritiesForRepo", () => {
+  test("sums Snyk severities", () => {
+    const result = countSeveritiesForRepo(
+      repo({
+        snyk: {
+          projects: [
+            snykProject({ critical: 1, high: 2, medium: 3, low: 4 }),
+            snykProject({ high: 1, medium: 0, low: 0 }),
+          ],
+        },
+      }),
+    )
+    expect(result).toStrictEqual({ critical: 1, high: 3, medium: 3, low: 4 })
+  })
+
+  test("maps GitHub MODERATE to medium and ignores dismissed alerts", () => {
+    const result = countSeveritiesForRepo(
+      repo({
+        github: {
+          orgName: "org",
+          repoName: "repo",
+          prs: [],
+          renovateDependencyDashboardIssue: null,
+          vulnerabilityAlerts: [
+            {
+              state: "OPEN",
+              dismissReason: null,
+              vulnerableManifestFilename: "",
+              vulnerableManifestPath: "",
+              vulnerableRequirements: null,
+              securityAdvisory: {
+                description: "",
+                identifiers: [],
+                references: [],
+                severity: "CRITICAL",
+              },
+              securityVulnerability: null,
+            },
+            {
+              state: "OPEN",
+              dismissReason: null,
+              vulnerableManifestFilename: "",
+              vulnerableManifestPath: "",
+              vulnerableRequirements: null,
+              securityAdvisory: {
+                description: "",
+                identifiers: [],
+                references: [],
+                severity: "MODERATE",
+              },
+              securityVulnerability: null,
+            },
+            {
+              state: "DISMISSED",
+              dismissReason: "fix_started",
+              vulnerableManifestFilename: "",
+              vulnerableManifestPath: "",
+              vulnerableRequirements: null,
+              securityAdvisory: {
+                description: "",
+                identifiers: [],
+                references: [],
+                severity: "HIGH",
+              },
+              securityVulnerability: null,
+            },
+          ],
+        },
+      }),
+    )
+    expect(result).toStrictEqual({ critical: 1, high: 0, medium: 1, low: 0 })
+  })
 })
 
-test("cutoff on monday with normal friday before", () => {
-  const wednesday = Temporal.Instant.from("2021-03-01T04:30:22.123Z")
-  const cutoff = calculateCutoffTimestamp(wednesday)
+describe("findOldPrs", () => {
+  test("filters bot authors and Snyk titles", () => {
+    const old = now.subtract({ hours: 24 * 40 }).toString()
+    const prs = findOldPrs(
+      repo({
+        github: {
+          orgName: "org",
+          repoName: "repo",
+          vulnerabilityAlerts: [],
+          renovateDependencyDashboardIssue: null,
+          prs: [
+            {
+              number: 1,
+              author: { login: "renovate" },
+              title: "deps",
+              createdAt: old,
+              updatedAt: old,
+            },
+            {
+              number: 2,
+              author: { login: "dependabot" },
+              title: "deps",
+              createdAt: old,
+              updatedAt: old,
+            },
+            {
+              number: 3,
+              author: { login: "alice" },
+              title: "[Snyk] fix",
+              createdAt: old,
+              updatedAt: old,
+            },
+            {
+              number: 4,
+              author: { login: "alice" },
+              title: "real work",
+              createdAt: old,
+              updatedAt: old,
+            },
+          ],
+        },
+      }),
+      now,
+    )
+    expect(prs).toStrictEqual([
+      { prNumber: 4, title: "real work", author: "alice", ageDays: 40 },
+    ])
+  })
 
-  expect(cutoff).toStrictEqual(Temporal.Instant.from("2021-02-26T06:30:00Z"))
+  test("filters PRs below age threshold", () => {
+    const recent = now.subtract({ hours: 24 * 5 }).toString()
+    const prs = findOldPrs(
+      repo({
+        github: {
+          orgName: "org",
+          repoName: "repo",
+          vulnerabilityAlerts: [],
+          renovateDependencyDashboardIssue: null,
+          prs: [
+            {
+              number: 1,
+              author: { login: "alice" },
+              title: "x",
+              createdAt: recent,
+              updatedAt: recent,
+            },
+          ],
+        },
+      }),
+      now,
+    )
+    expect(prs).toStrictEqual([])
+  })
 })
 
-test("cutoff on monday with friday before being holiday", () => {
-  const wednesday = Temporal.Instant.from("2021-01-04T04:30:22.123Z")
-  const cutoff = calculateCutoffTimestamp(wednesday)
+describe("buildReportData", () => {
+  test("groups by team alphabetically and computes totals", () => {
+    const snapshot: SnapshotData = {
+      timestamp: now.toString(),
+      metrics: [
+        repoWithSnyk({
+          repoId: "org/zeta",
+          responsible: "team-b",
+          severities: { critical: 1, high: 0, medium: 0, low: 0 },
+        }),
+        repoWithSnyk({
+          repoId: "org/alpha",
+          responsible: "team-a",
+          severities: { high: 2, medium: 0, low: 0 },
+        }),
+        repo({ repoId: "org/clean", responsible: "team-c" }),
+      ],
+    }
 
-  expect(cutoff).toStrictEqual(Temporal.Instant.from("2020-12-31T06:30:00Z"))
+    const data = buildReportData(snapshot, now)
+    expect(Object.keys(data.vulnReposByTeam)).toStrictEqual([
+      "team-a",
+      "team-b",
+    ])
+    expect(data.totals).toStrictEqual({
+      critical: 1,
+      high: 2,
+      medium: 0,
+      low: 0,
+    })
+    expect(data.reposWithVulnsCount).toBe(2)
+  })
+})
+
+describe("buildPerTeamMessages", () => {
+  test("produces one message per team with header carrying totals", () => {
+    const snapshot: SnapshotData = {
+      timestamp: now.toString(),
+      metrics: [
+        repoWithSnyk({
+          repoId: "org/a",
+          responsible: "team-a",
+          severities: { critical: 1, high: 2, medium: 3, low: 4 },
+        }),
+        repoWithSnyk({
+          repoId: "org/b",
+          responsible: "team-b",
+          severities: { high: 1, medium: 0, low: 0 },
+        }),
+      ],
+    }
+    const messages = buildPerTeamMessages(
+      buildReportData(snapshot, now),
+      "https://example/",
+    )
+    expect(messages.length).toBe(2)
+    const teamAMessage = messages[0]
+    expect(teamAMessage.text).toBe(
+      "team-a — 🟥 1 · 🟧 2 · 🟨 3 · 🟦 4 · Sum 10",
+    )
+    expect(teamAMessage.blocks[0]).toMatchObject({ type: "header" })
+    // The snapshot section follows the header and includes the date+time
+    // and the team-filtered dashboard URL.
+    const snapshotSection = teamAMessage.blocks[1]
+    expect(snapshotSection).toMatchObject({ type: "section" })
+    if (snapshotSection.type !== "section" || !snapshotSection.text)
+      throw new Error("expected section with text")
+    expect(snapshotSection.text.text).toContain("Snapshot: ")
+    expect(snapshotSection.text.text).toContain(
+      "https://example/?selectedTeams=team-a",
+    )
+  })
+
+  test("severity sections only include severities with non-zero totals", () => {
+    const snapshot: SnapshotData = {
+      timestamp: now.toString(),
+      metrics: [
+        repoWithSnyk({
+          repoId: "org/alpha",
+          responsible: "team-a",
+          severities: { high: 2, medium: 3, low: 0 },
+        }),
+        repoWithSnyk({
+          repoId: "org/beta",
+          responsible: "team-a",
+          severities: { critical: 1, high: 0, medium: 0, low: 0 },
+        }),
+      ],
+    }
+    const [message] = buildPerTeamMessages(
+      buildReportData(snapshot, now),
+      "https://example/",
+    )
+    const sectionTexts = message.blocks
+      .filter((b) => b.type === "section")
+      .map((b) => b.text?.text ?? "")
+
+    // Test data: alpha has high=2, med=3 (no crit, no low); beta has crit=1.
+    // Expect three section bodies after the snapshot section: Critical, High, Medium.
+    // Low is omitted because no repo contributes to it.
+    const critical = sectionTexts.find((t) => t.startsWith("🟥"))
+    const high = sectionTexts.find((t) => t.startsWith("🟧"))
+    const medium = sectionTexts.find((t) => t.startsWith("🟨"))
+    const low = sectionTexts.find((t) => t.startsWith("🟦"))
+
+    expect(critical).toContain("*Critical (1)*")
+    expect(critical).toContain(" 1")
+    expect(high).toContain("*High (2)*")
+    expect(high).toContain(" 2")
+    expect(medium).toContain("*Medium (3)*")
+    expect(medium).toContain(" 3")
+    expect(low).toBeUndefined()
+  })
+
+  test("severity-section links use repo name only (no org prefix)", () => {
+    const snapshot: SnapshotData = {
+      timestamp: now.toString(),
+      metrics: [
+        repo({
+          repoId: "liflig/liflig-logging",
+          github: {
+            orgName: "liflig",
+            repoName: "liflig-logging",
+            prs: [],
+            vulnerabilityAlerts: [],
+            renovateDependencyDashboardIssue: null,
+          },
+          responsible: "team-a",
+          snyk: { projects: [snykProject({ high: 1, medium: 0, low: 0 })] },
+        }),
+      ],
+    }
+    const [message] = buildPerTeamMessages(
+      buildReportData(snapshot, now),
+      "https://example/",
+    )
+    const json = JSON.stringify(message)
+    // Deep link filters to the repo AND opens the GitHub/Snyk vuln details
+    expect(json).toContain(
+      "https://example/?filterRepoName=liflig-logging&showVulGithubList=true&showVulSnykList=true",
+    )
+    // Display label is just the repo name — no "liflig/" prefix in the bullet
+    expect(json).toContain("|liflig-logging>")
+    expect(json).not.toContain("|liflig/liflig-logging>")
+  })
 })

--- a/packages/repo-collector/src/reporter/reporter.ts
+++ b/packages/repo-collector/src/reporter/reporter.ts
@@ -4,126 +4,370 @@ import type {
   SnapshotData,
   SnapshotMetrics,
 } from "@liflig/repo-metrics-repo-collector-types"
+import type { HeaderBlock, SectionBlock } from "@slack/types"
 import axios from "axios"
 import { groupBy, sortBy } from "lodash-es"
-import { isWorkingDay } from "../dates"
 
-interface ReportData {
-  timestamp: string
-  repos: ReportRepo[]
+type SlackBlock = HeaderBlock | SectionBlock
+
+export const OLD_PR_DAYS_THRESHOLD = 30
+
+const UNKNOWN_RESPONSIBLE = "Ukjent"
+
+export interface SeverityCounts {
+  critical: number
+  high: number
+  medium: number
+  low: number
 }
 
-interface ReportRepo {
+interface RepoRef {
   repoId: string
-  sumVulnerabilities: number
+  orgName: string
+  repoName: string
   responsible: string
 }
 
-export async function formatReportData(
-  snapshotData: SnapshotData,
-): Promise<ReportData | null> {
-  const reporterRepos = snapshotData.metrics.flatMap<ReportRepo>((metrics) => {
-    const sumVulnerabilities =
-      sumSnykSeverities(metrics.snyk.projects) +
-      sumGithubVuls(metrics.github.vulnerabilityAlerts)
+export interface VulnRepoEntry extends RepoRef {
+  severities: SeverityCounts
+  total: number
+}
 
-    return sumVulnerabilities === 0
-      ? []
-      : [
-          {
-            repoId: metrics.repoId,
-            sumVulnerabilities,
-            responsible: metrics.responsible ?? "Ukjent",
-          },
-        ]
-  })
+export interface OldPrEntry extends RepoRef {
+  prNumber: number
+  title: string
+  author: string
+  ageDays: number
+}
 
+export interface ReportData {
+  timestamp: string
+  totals: SeverityCounts
+  reposWithVulnsCount: number
+  vulnReposByTeam: Record<string, VulnRepoEntry[]>
+  oldPrsByTeam: Record<string, OldPrEntry[]>
+}
+
+function zeroSeverities(): SeverityCounts {
+  return { critical: 0, high: 0, medium: 0, low: 0 }
+}
+
+function addSeverities(a: SeverityCounts, b: SeverityCounts): SeverityCounts {
   return {
-    timestamp: snapshotData.timestamp,
-    repos: reporterRepos,
+    critical: a.critical + b.critical,
+    high: a.high + b.high,
+    medium: a.medium + b.medium,
+    low: a.low + b.low,
   }
 }
 
-export function generateMessage(reportData: ReportData): string {
-  const reposByResponsible = groupBy(
-    reportData.repos,
-    (repo) => repo.responsible,
-  )
-
-  const data = sortBy(
-    Object.values(reposByResponsible),
-    (it) => it[0].responsible,
-  ).map<string>((diffItems) => {
-    return (
-      `${diffItems[0].responsible}:\n` +
-      sortBy(diffItems, (repo) => repo.repoId)
-        .map((repo) => `${repo.repoId}: ${repo.sumVulnerabilities}`)
-        .join("\n")
-    )
-  })
-
-  const sumVulns = sumVulnerabilities(reportData.repos)
-
-  return `Repo Metrics - Sårbarheter
-
-Totalt antall sårbarheter: ${sumVulns}
-
-${data.length > 0 ? data.join("\n\n") : "Alt OK"}
-
-Siste datapunkt: ${reportData.timestamp}
-
-Detaljer: https://d2799m9v6pw1zy.cloudfront.net/`
+function totalOf(s: SeverityCounts): number {
+  return s.critical + s.high + s.medium + s.low
 }
 
-export async function sendSlackMessage(
-  slackWebhookUrl: string,
-  message: string,
-) {
-  await axios.post(slackWebhookUrl, {
-    text: message,
-  })
-}
-
-export function calculateCutoffTimestamp(
-  now: Temporal.Instant,
-): Temporal.Instant {
-  let cutoffDate = now.toZonedDateTimeISO("UTC").toPlainDate()
-
-  do {
-    cutoffDate = cutoffDate.subtract({ days: 1 })
-  } while (!isWorkingDay(cutoffDate))
-
-  // The job runs 6 am UTC, so pick a time a bit after this.
-  return cutoffDate
-    .toZonedDateTime({
-      plainTime: Temporal.PlainTime.from({ hour: 6, minute: 30 }),
-      timeZone: "UTC",
-    })
-    .toInstant()
-}
-
-function sumVulnerabilities(repos: ReportRepo[]) {
-  return repos.reduce((acc, cur) => acc + cur.sumVulnerabilities, 0)
-}
-
-function sumSnykSeverities(
+function snykSeverities(
   projects: SnapshotMetrics["snyk"]["projects"],
-): number {
-  return projects.reduce(
-    (acc, cur) =>
-      acc +
-      (cur.issueCountsBySeverity.critical ?? 0) +
-      cur.issueCountsBySeverity.high +
-      cur.issueCountsBySeverity.medium +
-      cur.issueCountsBySeverity.low,
-    0,
+): SeverityCounts {
+  return projects.reduce<SeverityCounts>(
+    (acc, p) => ({
+      critical: acc.critical + (p.issueCountsBySeverity.critical ?? 0),
+      high: acc.high + p.issueCountsBySeverity.high,
+      medium: acc.medium + p.issueCountsBySeverity.medium,
+      low: acc.low + p.issueCountsBySeverity.low,
+    }),
+    zeroSeverities(),
   )
 }
 
-function sumGithubVuls(
-  vulnerabilityAlerts: GitHubVulnerabilityAlert[],
-): number {
-  return vulnerabilityAlerts.filter((it) =>
-    it.state == null ? it.dismissReason == null : it.state === "OPEN",
-  ).length
+function githubSeverities(alerts: GitHubVulnerabilityAlert[]): SeverityCounts {
+  const counts = zeroSeverities()
+  for (const alert of alerts) {
+    const open =
+      alert.state == null ? alert.dismissReason == null : alert.state === "OPEN"
+    if (!open) continue
+    const sev = alert.securityAdvisory?.severity
+    if (sev === "CRITICAL") counts.critical += 1
+    else if (sev === "HIGH") counts.high += 1
+    else if (sev === "MODERATE") counts.medium += 1
+    else if (sev === "LOW") counts.low += 1
+    else counts.medium += 1
+  }
+  return counts
+}
+
+export function countSeveritiesForRepo(
+  metrics: SnapshotMetrics,
+): SeverityCounts {
+  return addSeverities(
+    snykSeverities(metrics.snyk.projects),
+    githubSeverities(metrics.github.vulnerabilityAlerts),
+  )
+}
+
+function daysBetween(from: Temporal.Instant, to: Temporal.Instant): number {
+  const diffMs = to.epochMilliseconds - from.epochMilliseconds
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+}
+
+function isBotPr(pr: { author: string; title: string }): boolean {
+  return (
+    ["dependabot", "renovate"].includes(pr.author) ||
+    pr.title.startsWith("[Snyk]")
+  )
+}
+
+export function findOldPrs(
+  metrics: SnapshotMetrics,
+  now: Temporal.Instant,
+): {
+  prNumber: number
+  title: string
+  author: string
+  ageDays: number
+}[] {
+  return metrics.github.prs.flatMap((pr) => {
+    const author = pr.author.login
+    if (isBotPr({ author, title: pr.title })) return []
+    const ageDays = daysBetween(Temporal.Instant.from(pr.createdAt), now)
+    if (ageDays < OLD_PR_DAYS_THRESHOLD) return []
+    return [{ prNumber: pr.number, title: pr.title, author, ageDays }]
+  })
+}
+
+function refOf(metrics: SnapshotMetrics): RepoRef {
+  return {
+    repoId: metrics.repoId,
+    orgName: metrics.github.orgName,
+    repoName: metrics.github.repoName,
+    responsible: metrics.responsible ?? UNKNOWN_RESPONSIBLE,
+  }
+}
+
+function groupByResponsibleSorted<T extends { responsible: string }>(
+  items: T[],
+  sortKey: (item: T) => string | number,
+): Record<string, T[]> {
+  const grouped = groupBy(items, (it) => it.responsible)
+  const result: Record<string, T[]> = {}
+  for (const team of Object.keys(grouped).sort((a, b) =>
+    a.localeCompare(b, "no"),
+  )) {
+    result[team] = sortBy(grouped[team], sortKey)
+  }
+  return result
+}
+
+export function buildReportData(
+  snapshotData: SnapshotData,
+  now: Temporal.Instant,
+): ReportData {
+  const vulnEntries: VulnRepoEntry[] = []
+  const oldPrEntries: OldPrEntry[] = []
+
+  for (const metrics of snapshotData.metrics) {
+    const ref = refOf(metrics)
+
+    const severities = countSeveritiesForRepo(metrics)
+    if (totalOf(severities) > 0) {
+      vulnEntries.push({ ...ref, severities, total: totalOf(severities) })
+    }
+
+    for (const pr of findOldPrs(metrics, now)) {
+      oldPrEntries.push({ ...ref, ...pr })
+    }
+  }
+
+  const totals = vulnEntries.reduce<SeverityCounts>(
+    (acc, e) => addSeverities(acc, e.severities),
+    zeroSeverities(),
+  )
+
+  return {
+    timestamp: snapshotData.timestamp,
+    totals,
+    reposWithVulnsCount: vulnEntries.length,
+    vulnReposByTeam: groupByResponsibleSorted(vulnEntries, (e) => e.repoId),
+    oldPrsByTeam: groupByResponsibleSorted(oldPrEntries, (e) => -e.ageDays),
+  }
+}
+
+function webappUrl(
+  webappBaseUrl: string,
+  params: Record<string, string>,
+): string {
+  const base = webappBaseUrl.replace(/\/+$/, "")
+  const query = Object.entries(params)
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join("&")
+  return `${base}/?${query}`
+}
+
+function githubPrUrl(
+  orgName: string,
+  repoName: string,
+  prNumber: number,
+): string {
+  return `https://github.com/${orgName}/${repoName}/pull/${prNumber}`
+}
+
+const SEV_CRITICAL = "🟥"
+const SEV_HIGH = "🟧"
+const SEV_MEDIUM = "🟨"
+const SEV_LOW = "🟦"
+
+function teamTitle(team: string, totals: SeverityCounts): string {
+  return (
+    `${team} — ` +
+    `${SEV_CRITICAL} ${totals.critical} · ` +
+    `${SEV_HIGH} ${totals.high} · ` +
+    `${SEV_MEDIUM} ${totals.medium} · ` +
+    `${SEV_LOW} ${totals.low} · ` +
+    `Sum ${totalOf(totals)}`
+  )
+}
+
+function formatDateTimeNo(timestamp: string): string {
+  const d = Temporal.Instant.from(timestamp).toZonedDateTimeISO("Europe/Oslo")
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${pad(d.day)}.${pad(d.month)}.${d.year} ${pad(d.hour)}:${pad(d.minute)}`
+}
+
+function header(text: string): HeaderBlock {
+  return { type: "header", text: { type: "plain_text", text, emoji: true } }
+}
+
+function section(markdown: string): SectionBlock {
+  return { type: "section", text: { type: "mrkdwn", text: markdown } }
+}
+
+// Slack section blocks cap text at 3000 chars.
+const SECTION_TEXT_LIMIT = 2900
+
+// Chunks `lines` across one or more section blocks, never exceeding Slack's
+// 3000-char section text limit. Optional `head` is prepended to the first
+// section's text; `cont` is prepended to each continuation section.
+function chunkLines(
+  lines: string[],
+  options: { head?: string; cont?: string } = {},
+): SectionBlock[] {
+  const sections: SectionBlock[] = []
+  let prefix = options.head ?? ""
+  let buf: string[] = []
+  let len = prefix.length
+
+  const flush = () => {
+    if (buf.length === 0) return
+    sections.push(
+      section(prefix ? `${prefix}\n${buf.join("\n")}` : buf.join("\n")),
+    )
+    buf = []
+    prefix = options.cont ?? ""
+    len = prefix.length
+  }
+
+  for (const line of lines) {
+    const added = line.length + 1
+    if (len + added > SECTION_TEXT_LIMIT && buf.length > 0) flush()
+    buf.push(line)
+    len += added
+  }
+  flush()
+  return sections
+}
+
+const SEVERITY_DEFS = [
+  { key: "critical", emoji: SEV_CRITICAL, label: "Critical" },
+  { key: "high", emoji: SEV_HIGH, label: "High" },
+  { key: "medium", emoji: SEV_MEDIUM, label: "Medium" },
+  { key: "low", emoji: SEV_LOW, label: "Low" },
+] as const
+
+// One section per non-empty severity, header "<emoji> *Label (total)*" plus
+// a bullet line per repo: "• <link|repo-name> N".
+function buildSeveritySections(
+  items: VulnRepoEntry[],
+  webappBaseUrl: string,
+): SectionBlock[] {
+  return SEVERITY_DEFS.flatMap((sev) => {
+    const repos = items.filter((e) => e.severities[sev.key] > 0)
+    if (repos.length === 0) return []
+    const total = repos.reduce((acc, e) => acc + e.severities[sev.key], 0)
+    const bullets = repos.map((e) => {
+      const url = webappUrl(webappBaseUrl, {
+        filterRepoName: e.repoName,
+        showVulGithubList: "true",
+        showVulSnykList: "true",
+      })
+      const link = `<${url}|${e.repoName}>`
+      return `• ${link} ${e.severities[sev.key]}`
+    })
+    return chunkLines(bullets, {
+      head: `${sev.emoji} *${sev.label} (${total})*`,
+      cont: `${sev.emoji} *${sev.label} (forts.)*`,
+    })
+  })
+}
+
+export interface SlackMessage {
+  text: string
+  blocks: SlackBlock[]
+}
+
+export function buildPerTeamMessages(
+  reportData: ReportData,
+  webappBaseUrl: string,
+): SlackMessage[] {
+  const messages: SlackMessage[] = []
+  const snapshotAt = formatDateTimeNo(reportData.timestamp)
+
+  for (const [team, items] of Object.entries(reportData.vulnReposByTeam)) {
+    // Per-team totals — distinct from reportData.totals which is the grand
+    // total across all teams.
+    const totals = items.reduce<SeverityCounts>(
+      (acc, e) => addSeverities(acc, e.severities),
+      zeroSeverities(),
+    )
+
+    const dashboardUrl = webappUrl(webappBaseUrl, { selectedTeams: team })
+
+    const blocks: SlackBlock[] = [
+      header(teamTitle(team, totals)),
+      section(`Snapshot: ${snapshotAt} · <${dashboardUrl}|Åpne dashboard>`),
+      ...buildSeveritySections(items, webappBaseUrl),
+    ]
+
+    const teamOldPrs = reportData.oldPrsByTeam[team] ?? []
+    if (teamOldPrs.length > 0) {
+      blocks.push(
+        header(`Gamle PR-er (>${OLD_PR_DAYS_THRESHOLD} dager, ekskl. bots)`),
+      )
+      blocks.push(
+        ...chunkLines(
+          teamOldPrs.map((e) => {
+            const url = githubPrUrl(e.orgName, e.repoName, e.prNumber)
+            const repoLabel = `${e.orgName}/${e.repoName}`
+            const title =
+              e.title.length > 80 ? `${e.title.slice(0, 77)}…` : e.title
+            return `• *${repoLabel}* — <${url}|#${e.prNumber} ${title}> — @${e.author}, ${e.ageDays} dager`
+          }),
+        ),
+      )
+    }
+
+    messages.push({
+      text: teamTitle(team, totals),
+      blocks,
+    })
+  }
+
+  return messages
+}
+
+export async function sendSlackMessages(
+  slackWebhookUrl: string,
+  messages: SlackMessage[],
+): Promise<void> {
+  for (const message of messages) {
+    await axios.post(slackWebhookUrl, message)
+  }
 }


### PR DESCRIPTION
- Splits the daily report into one Slack message per team.
- Header carries team name + per-severity totals + Sum.
- Bulleted repo links grouped by severity (Critical → Low) with deep links that open vuln details in the dashboard.
- Dashboard link in each message filters to that team via `selectedTeams`.
- Adds `@slack/types` for typed block construction.
- Reporter lambda gains a `WEBAPP_URL` env wired from the CloudFront domain.
- Taskfile `lambdas.report-locally` uses `interactive: true` to avoid go-task output buffering/truncation.