### PR TITLE
feat(reporter): render team vulns as a severity-column table

### DIFF
--- a/packages/repo-collector/src/reporter/reporter.test.ts
+++ b/packages/repo-collector/src/reporter/reporter.test.ts
@@ -291,10 +291,15 @@ describe("buildPerTeamMessages", () => {
     )
     expect(messages.length).toBe(2)
     const teamAMessage = messages[0]
+    // Notification fallback text still carries the severity breakdown.
     expect(teamAMessage.text).toBe(
       "team-a — 🟥 1 · 🟧 2 · 🟨 3 · 🟦 4 · Sum 10",
     )
-    expect(teamAMessage.blocks[0]).toMatchObject({ type: "header" })
+    // Header above the table is just the data set + team, no counts.
+    expect(teamAMessage.blocks[0]).toMatchObject({
+      type: "header",
+      text: { text: "Sårbarheter — team-a" },
+    })
     const snapshotSection = teamAMessage.blocks[1]
     expect(snapshotSection).toMatchObject({ type: "section" })
     if (snapshotSection.type !== "section" || !snapshotSection.text)
@@ -305,7 +310,7 @@ describe("buildPerTeamMessages", () => {
     )
   })
 
-  test("severity sections only include severities with non-zero totals", () => {
+  test("renders severities as table columns with a totals row", () => {
     const snapshot: SnapshotData = {
       timestamp: now.toString(),
       metrics: [
@@ -319,31 +324,52 @@ describe("buildPerTeamMessages", () => {
           responsible: "team-a",
           severities: ["CRITICAL"],
         }),
+        // No vulns — must not appear as a table row.
+        repo({ repoId: "org/clean", responsible: "team-a" }),
       ],
     }
     const [message] = buildPerTeamMessages(
       buildReportData(snapshot, now),
       "https://example/",
     )
-    const sectionTexts = message.blocks
-      .filter((b) => b.type === "section")
-      .map((b) => b.text?.text ?? "")
 
-    const critical = sectionTexts.find((t) => t.startsWith("🟥"))
-    const high = sectionTexts.find((t) => t.startsWith("🟧"))
-    const medium = sectionTexts.find((t) => t.startsWith("🟨"))
-    const low = sectionTexts.find((t) => t.startsWith("🟦"))
+    const table = message.blocks.find((b) => b.type === "table")
+    if (!table || table.type !== "table")
+      throw new Error("expected a table block")
 
-    expect(critical).toContain("*Critical (1)*")
-    expect(critical).toContain(" 1")
-    expect(high).toContain("*High (2)*")
-    expect(high).toContain(" 2")
-    expect(medium).toContain("*Medium (3)*")
-    expect(medium).toContain(" 3")
-    expect(low).toBeUndefined()
+    const rawText = (cell: unknown): string | undefined =>
+      typeof cell === "object" &&
+      cell !== null &&
+      (cell as any).type === "raw_text"
+        ? (cell as any).text
+        : undefined
+
+    const [headerRow, ...rest] = table.rows
+    const totalsRow = rest[rest.length - 1]
+    const bodyRows = rest.slice(0, -1)
+
+    expect(headerRow.map(rawText)).toStrictEqual([
+      "Repo",
+      "🟥 Critical",
+      "🟧 High",
+      "🟨 Medium",
+      "🟦 Low",
+      "Σ",
+    ])
+    // Clean repo dropped; only the two vulnerable repos remain.
+    expect(bodyRows.length).toBe(2)
+    // Grand totals; the empty Low column renders blank, not "0".
+    expect(totalsRow.map(rawText)).toStrictEqual([
+      "Sum",
+      "1",
+      "2",
+      "3",
+      " ",
+      "6",
+    ])
   })
 
-  test("severity-section links use repo name only (no org prefix)", () => {
+  test("table repo cells link by repo name only (no org prefix)", () => {
     const snapshot: SnapshotData = {
       timestamp: now.toString(),
       metrics: [
@@ -368,7 +394,7 @@ describe("buildPerTeamMessages", () => {
     expect(json).toContain(
       "https://example/?filterRepoName=liflig-logging&showVulGithubList=true",
     )
-    expect(json).toContain("|liflig-logging>")
-    expect(json).not.toContain("|liflig/liflig-logging>")
+    expect(json).toContain('"text":"liflig-logging"')
+    expect(json).not.toContain('"text":"liflig/liflig-logging"')
   })
 })

--- a/packages/repo-collector/src/reporter/reporter.ts
+++ b/packages/repo-collector/src/reporter/reporter.ts
@@ -4,11 +4,17 @@ import type {
   SnapshotData,
   SnapshotMetrics,
 } from "@liflig/repo-metrics-repo-collector-types"
-import type { HeaderBlock, SectionBlock } from "@slack/types"
+import type {
+  HeaderBlock,
+  RawTextElement,
+  RichTextBlock,
+  SectionBlock,
+  TableBlock,
+} from "@slack/types"
 import axios from "axios"
 import { groupBy, sortBy } from "lodash-es"
 
-type SlackBlock = HeaderBlock | SectionBlock
+type SlackBlock = HeaderBlock | SectionBlock | TableBlock
 
 export const OLD_PR_DAYS_THRESHOLD = 30
 
@@ -262,29 +268,67 @@ const SEVERITY_DEFS = [
   { key: "low", emoji: SEV_LOW, label: "Low" },
 ] as const
 
-// One section per non-empty severity, header "<emoji> *Label (total)*" plus
-// a bullet line per repo: "• <link|repo-name> N".
-function buildSeveritySections(
+function rawCell(text: string): RawTextElement {
+  return { type: "raw_text", text }
+}
+
+// 0 renders as blank. raw_text requires >= 1 char, so use a single space.
+function numCell(n: number): RawTextElement {
+  return rawCell(n === 0 ? " " : String(n))
+}
+
+function repoLinkCell(repoName: string, url: string): RichTextBlock {
+  return {
+    type: "rich_text",
+    elements: [
+      {
+        type: "rich_text_section",
+        elements: [{ type: "link", url, text: repoName }],
+      },
+    ],
+  }
+}
+
+// One row per repo (severity as columns), with a header row and a totals row.
+// Repo names link to the dashboard with the repo's vuln details expanded.
+function buildVulnTable(
   items: VulnRepoEntry[],
+  totals: SeverityCounts,
   webappBaseUrl: string,
-): SectionBlock[] {
-  return SEVERITY_DEFS.flatMap((sev) => {
-    const repos = items.filter((e) => e.severities[sev.key] > 0)
-    if (repos.length === 0) return []
-    const total = repos.reduce((acc, e) => acc + e.severities[sev.key], 0)
-    const bullets = repos.map((e) => {
-      const url = webappUrl(webappBaseUrl, {
-        filterRepoName: e.repoName,
-        showVulGithubList: "true",
-      })
-      const link = `<${url}|${e.repoName}>`
-      return `• ${link} ${e.severities[sev.key]}`
+): TableBlock {
+  const headerRow = [
+    rawCell("Repo"),
+    ...SEVERITY_DEFS.map((sev) => rawCell(`${sev.emoji} ${sev.label}`)),
+    rawCell("Σ"),
+  ]
+
+  const bodyRows = items.map((e) => {
+    const url = webappUrl(webappBaseUrl, {
+      filterRepoName: e.repoName,
+      showVulGithubList: "true",
     })
-    return chunkLines(bullets, {
-      head: `${sev.emoji} *${sev.label} (${total})*`,
-      cont: `${sev.emoji} *${sev.label} (forts.)*`,
-    })
+    return [
+      repoLinkCell(e.repoName, url),
+      ...SEVERITY_DEFS.map((sev) => numCell(e.severities[sev.key])),
+      numCell(e.total),
+    ]
   })
+
+  const totalsRow = [
+    rawCell("Sum"),
+    ...SEVERITY_DEFS.map((sev) => numCell(totals[sev.key])),
+    numCell(totalOf(totals)),
+  ]
+
+  return {
+    type: "table",
+    rows: [headerRow, ...bodyRows, totalsRow],
+    column_settings: [
+      { align: "left" },
+      ...SEVERITY_DEFS.map(() => ({ align: "right" as const })),
+      { align: "right" },
+    ],
+  }
 }
 
 export interface SlackMessage {
@@ -310,9 +354,9 @@ export function buildPerTeamMessages(
     const dashboardUrl = webappUrl(webappBaseUrl, { selectedTeams: team })
 
     const blocks: SlackBlock[] = [
-      header(teamTitle(team, totals)),
+      header(`Sårbarheter — ${team}`),
       section(`Snapshot: ${snapshotAt} · <${dashboardUrl}|Åpne dashboard>`),
-      ...buildSeveritySections(items, webappBaseUrl),
+      buildVulnTable(items, totals, webappBaseUrl),
     ]
 
     const teamOldPrs = reportData.oldPrsByTeam[team] ?? []


### PR DESCRIPTION
- Replace per-severity sections with a single native Slack `table` block
- One row per repo, severity as columns + Σ and a totals row
- Repo names are clickable rich-text links into the dashboard
- Zero counts render blank; repos without vulns are omitted