### PR TITLE
feat: integrate Aikido Security (Snyk successor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Requires:
 
 - Active AWS credentials for `liflig-incubator` (used to fetch the GitHub App credentials from Secrets Manager — see [API Key setup](#api-key-setup)).
 - Environment variable `SONARCLOUD_TOKEN`.
+- Environment variables `AIKIDO_CLIENT_ID` and `AIKIDO_CLIENT_SECRET`.
 
 ```shell
 $ task update-local-data
@@ -146,6 +147,28 @@ The PEM is handled separately — see [Rotating the GitHub App private key](#rot
 Set the following in `.envrc`:
 
 - `SONARCLOUD_TOKEN`
+
+### Aikido — REST API client credentials
+
+Aikido has no long-lived tokens. A workspace admin creates a REST API client under
+[Settings → Integrations → API](https://app.aikido.dev/settings/integrations/api/aikido/rest),
+which yields a client id + secret. The collector exchanges these for a short-lived
+access token (OAuth2 client-credentials grant) on each run.
+
+Credentials live in AWS Secrets Manager (region `eu-west-1`, account `liflig-incubator`):
+
+- `/incub/repo-metrics/aikido-api` — JSON `{ clientId, clientSecret }`.
+
+To populate the secret, add the values in `packages/infrastructure/load-secrets.ts`'s
+flow and run:
+
+```shell
+cd packages/infrastructure
+bun load-secrets.ts
+```
+
+The Lambda reads the secret at runtime via its IAM role. For local CLI runs, set
+`AIKIDO_CLIENT_ID` and `AIKIDO_CLIENT_SECRET` in `.envrc` instead.
 
 ## Rotating the GitHub App private key
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ access token (OAuth2 client-credentials grant) on each run.
 
 Credentials live in AWS Secrets Manager (region `eu-west-1`, account `liflig-incubator`):
 
-- `/incub/repo-metrics/aikido-api` — JSON `{ clientId, clientSecret }`.
+- `/incub/repo-metrics/aikido-client` — JSON `{ clientId, clientSecret }`.
 
 To populate the secret, add the values in `packages/infrastructure/load-secrets.ts`'s
 flow and run:

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2091,6 +2091,25 @@
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition"
+                    },
+                    ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-api-??????"
+                  ]
+                ]
+              }
+            },
+            {
+              "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
                 "s3:List*",
@@ -2171,6 +2190,18 @@
                     "Ref": "AWS::Partition"
                   },
                   ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/sonarcloud-token"
+                ]
+              ]
+            },
+            "AIKIDO_API_SECRET_ID": {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:",
+                  {
+                    "Ref": "AWS::Partition"
+                  },
+                  ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-api"
                 ]
               ]
             },

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2103,7 +2103,7 @@
                     {
                       "Ref": "AWS::Partition"
                     },
-                    ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-api-??????"
+                    ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-client-??????"
                   ]
                 ]
               }
@@ -2201,7 +2201,7 @@
                   {
                     "Ref": "AWS::Partition"
                   },
-                  ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-api"
+                  ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-client"
                 ]
               ]
             },

--- a/packages/infrastructure/load-secrets.ts
+++ b/packages/infrastructure/load-secrets.ts
@@ -34,8 +34,8 @@ const sonarCloudTokenSecret: loadSecrets.Secret = {
   ],
 }
 
-const aikidoApiSecret: loadSecrets.Secret = {
-  name: "aikido-api",
+const aikidoClientSecret: loadSecrets.Secret = {
+  name: "aikido-client",
   description: "Aikido REST API client credentials (client id + secret)",
   type: "json",
   fields: [
@@ -67,7 +67,7 @@ loadSecrets.loadSecretsCli({
       description: "incub",
       namePrefix: "/incub/repo-metrics/",
       secrets: [
-        aikidoApiSecret,
+        aikidoClientSecret,
         githubAppSecret,
         reporterSlackWebhookUrlSecret,
         slackPipelineNotificationWebhookUrl,

--- a/packages/infrastructure/load-secrets.ts
+++ b/packages/infrastructure/load-secrets.ts
@@ -34,6 +34,20 @@ const sonarCloudTokenSecret: loadSecrets.Secret = {
   ],
 }
 
+const aikidoApiSecret: loadSecrets.Secret = {
+  name: "aikido-api",
+  description: "Aikido REST API client credentials (client id + secret)",
+  type: "json",
+  fields: [
+    {
+      key: "clientId",
+    },
+    {
+      key: "clientSecret",
+    },
+  ],
+}
+
 const reporterSlackWebhookUrlSecret: loadSecrets.Secret = {
   name: "reporter-slack-webhook-url",
   description: "Slack Webhook URL for data reporting",
@@ -53,6 +67,7 @@ loadSecrets.loadSecretsCli({
       description: "incub",
       namePrefix: "/incub/repo-metrics/",
       secrets: [
+        aikidoApiSecret,
         githubAppSecret,
         reporterSlackWebhookUrlSecret,
         slackPipelineNotificationWebhookUrl,

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -110,6 +110,12 @@ export class RepoMetricsStack extends cdk.Stack {
       "/incub/repo-metrics/sonarcloud-token",
     )
 
+    const aikidoApiSecret = secretsmanager.Secret.fromSecretNameV2(
+      this,
+      "AikidoApiSecret",
+      "/incub/repo-metrics/aikido-api",
+    )
+
     const collectorFn = new lambda.Function(this, "Collector", {
       code: lambda.Code.fromAsset("../repo-collector/dist"),
       handler: "index.collectHandler",
@@ -120,6 +126,7 @@ export class RepoMetricsStack extends cdk.Stack {
         GITHUB_APP_SECRET_ID: githubAppSecret.secretArn,
         GITHUB_APP_ORG: "capralifecycle",
         SONARCLOUD_TOKEN_SECRET_ID: sonarCloudTokenSecret.secretArn,
+        AIKIDO_API_SECRET_ID: aikidoApiSecret.secretArn,
         DATA_BUCKET_NAME: dataBucket.bucketName,
         // Lambda only has /tmp as writable, needed for CacheProvider
         XDG_CACHE_HOME: "/tmp",
@@ -128,6 +135,7 @@ export class RepoMetricsStack extends cdk.Stack {
 
     githubAppSecret.grantRead(collectorFn)
     sonarCloudTokenSecret.grantRead(collectorFn)
+    aikidoApiSecret.grantRead(collectorFn)
     dataBucket.grantReadWrite(collectorFn)
 
     const aggregatorMemoryMB = 300

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -110,10 +110,10 @@ export class RepoMetricsStack extends cdk.Stack {
       "/incub/repo-metrics/sonarcloud-token",
     )
 
-    const aikidoApiSecret = secretsmanager.Secret.fromSecretNameV2(
+    const aikidoClientSecret = secretsmanager.Secret.fromSecretNameV2(
       this,
-      "AikidoApiSecret",
-      "/incub/repo-metrics/aikido-api",
+      "AikidoClientSecret",
+      "/incub/repo-metrics/aikido-client",
     )
 
     const collectorFn = new lambda.Function(this, "Collector", {
@@ -126,7 +126,7 @@ export class RepoMetricsStack extends cdk.Stack {
         GITHUB_APP_SECRET_ID: githubAppSecret.secretArn,
         GITHUB_APP_ORG: "capralifecycle",
         SONARCLOUD_TOKEN_SECRET_ID: sonarCloudTokenSecret.secretArn,
-        AIKIDO_API_SECRET_ID: aikidoApiSecret.secretArn,
+        AIKIDO_API_SECRET_ID: aikidoClientSecret.secretArn,
         DATA_BUCKET_NAME: dataBucket.bucketName,
         // Lambda only has /tmp as writable, needed for CacheProvider
         XDG_CACHE_HOME: "/tmp",
@@ -135,7 +135,7 @@ export class RepoMetricsStack extends cdk.Stack {
 
     githubAppSecret.grantRead(collectorFn)
     sonarCloudTokenSecret.grantRead(collectorFn)
-    aikidoApiSecret.grantRead(collectorFn)
+    aikidoClientSecret.grantRead(collectorFn)
     dataBucket.grantReadWrite(collectorFn)
 
     const aggregatorMemoryMB = 300

--- a/packages/repo-collector-types/src/index.ts
+++ b/packages/repo-collector-types/src/index.ts
@@ -72,15 +72,16 @@ export type AikidoSeverity = "critical" | "high" | "medium" | "low"
 export interface AikidoMetrics {
   /** Whether the repo is onboarded in Aikido (present in its code repo list). */
   enabled: boolean
+  /** The repo's Aikido id, used to deep-link into its issues. Null when disabled. */
+  repoId: number | null
   issueGroups: AikidoIssueGroup[]
   /** Number of ignored (open but muted) issue groups for the repo. */
   ignoredCount: number
 }
 
 export interface AikidoIssueGroup {
+  /** The issue group id — Aikido's queue/sidebar deep-links key on this. */
   groupId: number
-  /** A representative issue id in the group, used to deep-link into Aikido. */
-  issueId: number
   severity: AikidoSeverity
   /** e.g. open_source, sast, leaked_secret, iac, cloud, malware, eol. */
   type: string
@@ -186,11 +187,13 @@ export interface Metrics {
   aikido: {
     /** Whether the repo is onboarded in Aikido. `false` renders as "no data". */
     enabled: boolean
+    /** The repo's Aikido id, for deep-linking issues. Null when disabled. */
+    repoId: number | null
     /** Ignored (muted) issue groups, shown separately from the open counts. */
     ignoredCount: number
     /** Deduplicated open issue groups. */
     issues: {
-      issueId: number
+      groupId: number
       severity: AikidoSeverity
       type: string
       title: string

--- a/packages/repo-collector-types/src/index.ts
+++ b/packages/repo-collector-types/src/index.ts
@@ -54,6 +54,34 @@ export interface SnapshotMetrics {
       }[]
     }
   }
+  // Added 2026-07: Aikido security. Absent on snapshots collected before the
+  // integration; consumers must treat it as optional.
+  aikido?: AikidoMetrics
+}
+
+export type AikidoSeverity = "critical" | "high" | "medium" | "low"
+
+/**
+ * Aikido issue groups for a single repo, embedded in a snapshot.
+ *
+ * Issues are deduplicated to their issue group (Aikido's own grouping of the
+ * same underlying finding across files), keeping the highest severity seen for
+ * the group. Only security-relevant issue types are included (see
+ * `ISSUE_TYPES` in `aikido/service.ts`).
+ */
+export interface AikidoMetrics {
+  /** Whether the repo is onboarded in Aikido (present in its code repo list). */
+  enabled: boolean
+  issueGroups: AikidoIssueGroup[]
+}
+
+export interface AikidoIssueGroup {
+  groupId: number
+  severity: AikidoSeverity
+  /** e.g. open_source, sast, leaked_secret, iac, cloud, malware, eol. */
+  type: string
+  /** Display label: cve id, else affected package, else the issue type. */
+  name: string
 }
 
 export interface GitHubVulnerabilityAlert {
@@ -150,5 +178,15 @@ export interface Metrics {
      * Undefined means that no test coverage has been set up
      */
     testCoverage?: string
+  }
+  aikido: {
+    /** Whether the repo is onboarded in Aikido. `false` renders as "no data". */
+    enabled: boolean
+    /** Deduplicated issue groups; the displayed count is `issues.length`. */
+    issues: {
+      severity: AikidoSeverity
+      type: string
+      name: string
+    }[]
   }
 }

--- a/packages/repo-collector-types/src/index.ts
+++ b/packages/repo-collector-types/src/index.ts
@@ -73,15 +73,19 @@ export interface AikidoMetrics {
   /** Whether the repo is onboarded in Aikido (present in its code repo list). */
   enabled: boolean
   issueGroups: AikidoIssueGroup[]
+  /** Number of ignored (open but muted) issue groups for the repo. */
+  ignoredCount: number
 }
 
 export interface AikidoIssueGroup {
   groupId: number
+  /** A representative issue id in the group, used to deep-link into Aikido. */
+  issueId: number
   severity: AikidoSeverity
   /** e.g. open_source, sast, leaked_secret, iac, cloud, malware, eol. */
   type: string
-  /** Display label: cve id, else affected package, else the issue type. */
-  name: string
+  /** Human-readable title as shown in Aikido, e.g. "fast-uri", "3 exposed secrets". */
+  title: string
 }
 
 export interface GitHubVulnerabilityAlert {
@@ -182,11 +186,14 @@ export interface Metrics {
   aikido: {
     /** Whether the repo is onboarded in Aikido. `false` renders as "no data". */
     enabled: boolean
-    /** Deduplicated issue groups; the displayed count is `issues.length`. */
+    /** Ignored (muted) issue groups, shown separately from the open counts. */
+    ignoredCount: number
+    /** Deduplicated open issue groups. */
     issues: {
+      issueId: number
       severity: AikidoSeverity
       type: string
-      name: string
+      title: string
     }[]
   }
 }

--- a/packages/repo-collector/src/aikido/service.test.ts
+++ b/packages/repo-collector/src/aikido/service.test.ts
@@ -60,30 +60,98 @@ const REPOS = [
 ]
 
 const ISSUES = [
-  // repo-a group 10 appears twice with different severities -> dedupe, keep critical.
-  issue({ group_id: 10, severity: "high", type: "open_source", repo: 1 }),
-  issue({ group_id: 10, severity: "critical", type: "open_source", repo: 1 }),
-  issue({ group_id: 11, severity: "high", type: "sast", repo: 1 }),
+  // repo-a group 10 appears twice with different severities -> dedupe, keep critical;
+  // title comes from the affected package.
+  issue({
+    id: 100,
+    group_id: 10,
+    severity: "high",
+    type: "open_source",
+    repo: 1,
+    affected_package: "fast-uri",
+  }),
+  issue({
+    id: 101,
+    group_id: 10,
+    severity: "critical",
+    type: "open_source",
+    repo: 1,
+    affected_package: "fast-uri",
+  }),
+  // sast title comes from the rule name.
+  issue({
+    id: 110,
+    group_id: 11,
+    severity: "high",
+    type: "sast",
+    repo: 1,
+    rule: "SQL injection",
+  }),
   // license is excluded from ISSUE_TYPES.
-  issue({ group_id: 12, severity: "low", type: "license", repo: 1 }),
-  issue({ group_id: 20, severity: "medium", type: "leaked_secret", repo: 2 }),
+  issue({ id: 120, group_id: 12, severity: "low", type: "license", repo: 1 }),
+  // repo-b group 20: three leaked secrets -> aggregated title.
+  issue({
+    id: 200,
+    group_id: 20,
+    severity: "medium",
+    type: "leaked_secret",
+    repo: 2,
+  }),
+  issue({
+    id: 201,
+    group_id: 20,
+    severity: "medium",
+    type: "leaked_secret",
+    repo: 2,
+  }),
+  issue({
+    id: 202,
+    group_id: 20,
+    severity: "medium",
+    type: "leaked_secret",
+    repo: 2,
+  }),
+]
+
+// Ignored issues are fetched separately; one ignored group for repo-a.
+const IGNORED = [
+  issue({
+    id: 900,
+    group_id: 90,
+    severity: "high",
+    type: "open_source",
+    repo: 1,
+    affected_package: "left-pad",
+  }),
 ]
 
 function issue(opts: {
+  id: number
   group_id: number
   severity: string
   type: string
   repo: number
+  affected_package?: string | null
+  rule?: string | null
 }) {
   return {
+    id: opts.id,
     group_id: opts.group_id,
     severity: opts.severity,
     type: opts.type,
     code_repo_id: opts.repo,
     code_repo_name: `repo-${opts.repo}`,
     cve_id: `CVE-${opts.group_id}`,
-    affected_package: null,
+    affected_package: opts.affected_package ?? null,
+    rule: opts.rule ?? null,
   }
+}
+
+// Routes an /issues/export request to open vs ignored fixtures by filter_status.
+function exportResponse(url: string, open: unknown, ignored: unknown) {
+  return url.includes("filter_status=ignored")
+    ? jsonResponse(ignored)
+    : jsonResponse(open)
 }
 
 afterEach(() => {
@@ -91,7 +159,7 @@ afterEach(() => {
 })
 
 describe("getIssueGroupsByRepo", () => {
-  test("filters types, dedupes by group id, groups per repo", async () => {
+  test("filters types, dedupes by group id, derives titles, counts ignored", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string) => {
@@ -99,7 +167,9 @@ describe("getIssueGroupsByRepo", () => {
           return jsonResponse({ access_token: "tok", token_type: "bearer" })
         }
         if (url.includes("/repositories/code")) return jsonResponse(REPOS)
-        if (url.includes("/issues/export")) return jsonResponse(ISSUES)
+        if (url.includes("/issues/export")) {
+          return exportResponse(url, ISSUES, IGNORED)
+        }
         throw new Error(`unexpected url ${url}`)
       }),
     )
@@ -112,20 +182,30 @@ describe("getIssueGroupsByRepo", () => {
     expect(repoA?.issueGroups).toHaveLength(2)
     const group10 = repoA?.issueGroups.find((g) => g.groupId === 10)
     expect(group10?.severity).toBe("critical") // highest severity wins
-    expect(group10?.name).toBe("CVE-10")
+    expect(group10?.issueId).toBe(101) // representative issue = highest severity
+    expect(group10?.title).toBe("fast-uri") // title from affected package
+    const group11 = repoA?.issueGroups.find((g) => g.groupId === 11)
+    expect(group11?.title).toBe("SQL injection") // title from rule name
+    // Ignored issues are counted separately.
+    expect(repoA?.ignoredCount).toBe(1)
 
     const repoB = byRepo.get("repo-b")
     expect(repoB?.issueGroups).toEqual([
       {
         groupId: 20,
+        issueId: 200,
         severity: "medium",
         type: "leaked_secret",
-        name: "CVE-20",
+        title: "3 exposed secrets", // aggregated secret title
       },
     ])
 
-    // Onboarded repo with no issues is enabled with an empty list.
-    expect(byRepo.get("repo-c")).toEqual({ enabled: true, issueGroups: [] })
+    // Onboarded repo with no issues is enabled with empty counts.
+    expect(byRepo.get("repo-c")).toEqual({
+      enabled: true,
+      issueGroups: [],
+      ignoredCount: 0,
+    })
   })
 
   test("repos are also keyed by their URL repo slug", async () => {

--- a/packages/repo-collector/src/aikido/service.test.ts
+++ b/packages/repo-collector/src/aikido/service.test.ts
@@ -182,8 +182,8 @@ describe("getIssueGroupsByRepo", () => {
     expect(repoA?.issueGroups).toHaveLength(2)
     const group10 = repoA?.issueGroups.find((g) => g.groupId === 10)
     expect(group10?.severity).toBe("critical") // highest severity wins
-    expect(group10?.issueId).toBe(101) // representative issue = highest severity
     expect(group10?.title).toBe("fast-uri") // title from affected package
+    expect(repoA?.repoId).toBe(1) // Aikido repo id, used for deep links
     const group11 = repoA?.issueGroups.find((g) => g.groupId === 11)
     expect(group11?.title).toBe("SQL injection") // title from rule name
     // Ignored issues are counted separately.
@@ -193,7 +193,6 @@ describe("getIssueGroupsByRepo", () => {
     expect(repoB?.issueGroups).toEqual([
       {
         groupId: 20,
-        issueId: 200,
         severity: "medium",
         type: "leaked_secret",
         title: "3 exposed secrets", // aggregated secret title
@@ -203,6 +202,7 @@ describe("getIssueGroupsByRepo", () => {
     // Onboarded repo with no issues is enabled with empty counts.
     expect(byRepo.get("repo-c")).toEqual({
       enabled: true,
+      repoId: 3,
       issueGroups: [],
       ignoredCount: 0,
     })

--- a/packages/repo-collector/src/aikido/service.test.ts
+++ b/packages/repo-collector/src/aikido/service.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { Config } from "../config"
+import { AikidoService } from "./service"
+
+const credentialsProvider = {
+  getCredentials: async () => ({
+    clientId: "id",
+    clientSecret: "secret",
+  }),
+}
+
+function service(): AikidoService {
+  return new AikidoService({
+    config: new Config(),
+    credentialsProvider,
+  })
+}
+
+interface FakeResponseInit {
+  status?: number
+  headers?: Record<string, string>
+}
+
+function jsonResponse(body: unknown, init: FakeResponseInit = {}) {
+  const status = init.status ?? 200
+  const headers = new Map(
+    Object.entries(init.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]),
+  )
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => headers.get(name.toLowerCase()) ?? null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }
+}
+
+const REPOS = [
+  {
+    id: 1,
+    name: "repo-a",
+    provider: "github",
+    external_repo_id: "R_a",
+    url: "https://github.com/capralifecycle/repo-a",
+  },
+  {
+    id: 2,
+    name: "repo-b",
+    provider: "github",
+    external_repo_id: "R_b",
+    url: "https://github.com/capralifecycle/repo-b",
+  },
+  {
+    id: 3,
+    name: "repo-c",
+    provider: "github",
+    external_repo_id: "R_c",
+    url: "https://github.com/capralifecycle/repo-c",
+  },
+]
+
+const ISSUES = [
+  // repo-a group 10 appears twice with different severities -> dedupe, keep critical.
+  issue({ group_id: 10, severity: "high", type: "open_source", repo: 1 }),
+  issue({ group_id: 10, severity: "critical", type: "open_source", repo: 1 }),
+  issue({ group_id: 11, severity: "high", type: "sast", repo: 1 }),
+  // license is excluded from ISSUE_TYPES.
+  issue({ group_id: 12, severity: "low", type: "license", repo: 1 }),
+  issue({ group_id: 20, severity: "medium", type: "leaked_secret", repo: 2 }),
+]
+
+function issue(opts: {
+  group_id: number
+  severity: string
+  type: string
+  repo: number
+}) {
+  return {
+    group_id: opts.group_id,
+    severity: opts.severity,
+    type: opts.type,
+    code_repo_id: opts.repo,
+    code_repo_name: `repo-${opts.repo}`,
+    cve_id: `CVE-${opts.group_id}`,
+    affected_package: null,
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("getIssueGroupsByRepo", () => {
+  test("filters types, dedupes by group id, groups per repo", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/oauth/token")) {
+          return jsonResponse({ access_token: "tok", token_type: "bearer" })
+        }
+        if (url.includes("/repositories/code")) return jsonResponse(REPOS)
+        if (url.includes("/issues/export")) return jsonResponse(ISSUES)
+        throw new Error(`unexpected url ${url}`)
+      }),
+    )
+
+    const byRepo = await service().getIssueGroupsByRepo()
+
+    const repoA = byRepo.get("repo-a")
+    expect(repoA?.enabled).toBe(true)
+    // group 12 (license) excluded; group 10 deduped to one entry.
+    expect(repoA?.issueGroups).toHaveLength(2)
+    const group10 = repoA?.issueGroups.find((g) => g.groupId === 10)
+    expect(group10?.severity).toBe("critical") // highest severity wins
+    expect(group10?.name).toBe("CVE-10")
+
+    const repoB = byRepo.get("repo-b")
+    expect(repoB?.issueGroups).toEqual([
+      {
+        groupId: 20,
+        severity: "medium",
+        type: "leaked_secret",
+        name: "CVE-20",
+      },
+    ])
+
+    // Onboarded repo with no issues is enabled with an empty list.
+    expect(byRepo.get("repo-c")).toEqual({ enabled: true, issueGroups: [] })
+  })
+
+  test("repos are also keyed by their URL repo slug", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/oauth/token")) {
+          return jsonResponse({ access_token: "tok" })
+        }
+        if (url.includes("/repositories/code")) {
+          return jsonResponse([
+            {
+              id: 9,
+              name: "Display Name",
+              provider: "github",
+              external_repo_id: "R_x",
+              url: "https://github.com/capralifecycle/actual-slug",
+            },
+          ])
+        }
+        if (url.includes("/issues/export")) return jsonResponse([])
+        throw new Error(`unexpected url ${url}`)
+      }),
+    )
+
+    const byRepo = await service().getIssueGroupsByRepo()
+    expect(byRepo.get("actual-slug")?.enabled).toBe(true)
+    expect(byRepo.get("display name")?.enabled).toBe(true)
+  })
+
+  test("retries on 429 honoring Retry-After", async () => {
+    let reposCalls = 0
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/oauth/token")) {
+          return jsonResponse({ access_token: "tok" })
+        }
+        if (url.includes("/repositories/code")) {
+          reposCalls++
+          if (reposCalls === 1) {
+            return jsonResponse(
+              { error: "rate limited" },
+              { status: 429, headers: { "retry-after": "0" } },
+            )
+          }
+          return jsonResponse(REPOS)
+        }
+        if (url.includes("/issues/export")) return jsonResponse([])
+        throw new Error(`unexpected url ${url}`)
+      }),
+    )
+
+    const byRepo = await service().getIssueGroupsByRepo()
+    expect(reposCalls).toBe(2)
+    expect(byRepo.get("repo-a")?.enabled).toBe(true)
+  })
+
+  test("throws on token exchange failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/oauth/token")) {
+          return jsonResponse({ error: "nope" }, { status: 401 })
+        }
+        return jsonResponse([])
+      }),
+    )
+
+    await expect(service().getIssueGroupsByRepo()).rejects.toThrow(
+      /token exchange failed/,
+    )
+  })
+})

--- a/packages/repo-collector/src/aikido/service.ts
+++ b/packages/repo-collector/src/aikido/service.ts
@@ -48,6 +48,7 @@ interface AikidoCodeRepo {
 }
 
 interface AikidoIssue {
+  id: number
   group_id: number
   severity: AikidoSeverity
   type: string
@@ -55,7 +56,11 @@ interface AikidoIssue {
   code_repo_name: string
   cve_id: string | null
   affected_package: string | null
+  /** Name of the rule that produced the finding, e.g. "SQL injection". */
+  rule: string | null
 }
+
+type IssueStatus = "open" | "ignored" | "snoozed" | "closed"
 
 interface TokenResponse {
   access_token: string
@@ -174,11 +179,11 @@ export class AikidoService {
     return repos
   }
 
-  private async exportOpenIssues(): Promise<AikidoIssue[]> {
+  private async exportIssues(status: IssueStatus): Promise<AikidoIssue[]> {
     const issues: AikidoIssue[] = []
     for (let page = 0; ; page++) {
       const batch = await this.apiGet<AikidoIssue[]>(
-        `/issues/export?format=json&filter_status=open&page=${page}&per_page=${ISSUES_PER_PAGE}`,
+        `/issues/export?format=json&filter_status=${status}&page=${page}&per_page=${ISSUES_PER_PAGE}`,
       )
       issues.push(...batch)
       if (batch.length < ISSUES_PER_PAGE) break
@@ -187,26 +192,30 @@ export class AikidoService {
   }
 
   /**
-   * Fetch all onboarded repos and open issues, then aggregate into per-repo
-   * metrics. Issues are filtered to security-relevant `ISSUE_TYPES` and
-   * deduplicated by `group_id` (keeping the highest severity).
+   * Fetch all onboarded repos, their open issues, and their ignored issues,
+   * then aggregate into per-repo metrics. Issues are filtered to
+   * security-relevant `ISSUE_TYPES` and deduplicated by `group_id` (keeping the
+   * highest severity).
    *
    * Returns a map keyed by lowercased repo name (both the Aikido repo name and
    * the repo slug from its URL, so lookups by GitHub repo name resolve).
    */
   public async getIssueGroupsByRepo(): Promise<Map<string, AikidoMetrics>> {
-    const [repos, issues] = await Promise.all([
+    const [repos, openIssues, ignoredIssues] = await Promise.all([
       this.listCodeRepos(),
-      this.exportOpenIssues(),
+      this.exportIssues("open"),
+      this.exportIssues("ignored"),
     ])
 
-    const groupsByRepoId = groupIssuesByRepo(issues)
+    const groupsByRepoId = groupIssuesByRepo(openIssues)
+    const ignoredByRepoId = countGroupsByRepo(ignoredIssues)
 
     const byName = new Map<string, AikidoMetrics>()
     for (const repo of repos) {
       const metrics: AikidoMetrics = {
         enabled: true,
         issueGroups: groupsByRepoId.get(repo.id) ?? [],
+        ignoredCount: ignoredByRepoId.get(repo.id) ?? 0,
       }
       for (const key of repoLookupKeys(repo)) {
         byName.set(key, metrics)
@@ -224,11 +233,22 @@ function repoLookupKeys(repo: AikidoCodeRepo): string[] {
   return keys
 }
 
+interface GroupAccumulator {
+  groupId: number
+  issueId: number
+  severity: AikidoSeverity
+  type: string
+  count: number
+  affectedPackage: string | null
+  rule: string | null
+  cveId: string | null
+}
+
 function groupIssuesByRepo(
   issues: AikidoIssue[],
 ): Map<number, AikidoIssueGroup[]> {
-  // repoId -> groupId -> group (highest severity wins).
-  const perRepo = new Map<number, Map<number, AikidoIssueGroup>>()
+  // repoId -> groupId -> accumulator (highest severity wins, count tracked).
+  const perRepo = new Map<number, Map<number, GroupAccumulator>>()
 
   for (const issue of issues) {
     if (!ISSUE_TYPES.has(issue.type)) continue
@@ -239,26 +259,66 @@ function groupIssuesByRepo(
       perRepo.set(issue.code_repo_id, groups)
     }
 
-    const candidate: AikidoIssueGroup = {
-      groupId: issue.group_id,
-      severity: issue.severity,
-      type: issue.type,
-      name: issue.cve_id ?? issue.affected_package ?? issue.type,
-    }
-
     const existing = groups.get(issue.group_id)
-    if (
-      !existing ||
-      SEVERITY_RANK[candidate.severity] > SEVERITY_RANK[existing.severity]
-    ) {
-      groups.set(issue.group_id, candidate)
+    if (!existing) {
+      groups.set(issue.group_id, {
+        groupId: issue.group_id,
+        issueId: issue.id,
+        severity: issue.severity,
+        type: issue.type,
+        count: 1,
+        affectedPackage: issue.affected_package,
+        rule: issue.rule,
+        cveId: issue.cve_id,
+      })
+    } else {
+      existing.count += 1
+      if (SEVERITY_RANK[issue.severity] > SEVERITY_RANK[existing.severity]) {
+        existing.severity = issue.severity
+        existing.issueId = issue.id
+      }
     }
   }
 
   const result = new Map<number, AikidoIssueGroup[]>()
   for (const [repoId, groups] of perRepo) {
-    result.set(repoId, [...groups.values()])
+    result.set(
+      repoId,
+      [...groups.values()].map((g) => ({
+        groupId: g.groupId,
+        issueId: g.issueId,
+        severity: g.severity,
+        type: g.type,
+        title: deriveTitle(g),
+      })),
+    )
   }
+  return result
+}
+
+// Aikido's human-readable title. Secrets are aggregated ("N exposed secrets");
+// dependency vulns show the package, SAST/IaC/etc. show the rule name.
+function deriveTitle(g: GroupAccumulator): string {
+  if (g.type === "leaked_secret") {
+    return g.count > 1 ? `${g.count} exposed secrets` : "Exposed secret"
+  }
+  return g.affectedPackage ?? g.rule ?? g.cveId ?? g.type
+}
+
+// Counts distinct issue groups per repo (used for the ignored-issue count).
+function countGroupsByRepo(issues: AikidoIssue[]): Map<number, number> {
+  const perRepo = new Map<number, Set<number>>()
+  for (const issue of issues) {
+    if (!ISSUE_TYPES.has(issue.type)) continue
+    let groups = perRepo.get(issue.code_repo_id)
+    if (!groups) {
+      groups = new Set()
+      perRepo.set(issue.code_repo_id, groups)
+    }
+    groups.add(issue.group_id)
+  }
+  const result = new Map<number, number>()
+  for (const [repoId, groups] of perRepo) result.set(repoId, groups.size)
   return result
 }
 

--- a/packages/repo-collector/src/aikido/service.ts
+++ b/packages/repo-collector/src/aikido/service.ts
@@ -1,0 +1,278 @@
+import type { Agent } from "node:https"
+import type {
+  AikidoIssueGroup,
+  AikidoMetrics,
+  AikidoSeverity,
+} from "@liflig/repo-metrics-repo-collector-types"
+import type { Config } from "../config"
+import type { AikidoCredentials, AikidoCredentialsProvider } from "./token"
+import { AikidoCredentialsCliProvider } from "./token"
+
+type FetchOptions = RequestInit & { agent: Agent }
+
+const AIKIDO_BASE_URL = "https://app.aikido.dev"
+const TOKEN_URL = `${AIKIDO_BASE_URL}/api/oauth/token`
+const API_BASE = `${AIKIDO_BASE_URL}/api/public/v1`
+
+const REPOS_PER_PAGE = 200
+const ISSUES_PER_PAGE = 5000
+const MAX_RETRIES = 5
+
+/**
+ * Issue types counted as "vulnerabilities". Excludes `license` (compliance, not
+ * a security finding). Single source of truth for the collection scope.
+ */
+export const ISSUE_TYPES = new Set([
+  "open_source",
+  "sast",
+  "leaked_secret",
+  "iac",
+  "cloud",
+  "malware",
+  "eol",
+])
+
+const SEVERITY_RANK: Record<AikidoSeverity, number> = {
+  critical: 3,
+  high: 2,
+  medium: 1,
+  low: 0,
+}
+
+interface AikidoCodeRepo {
+  id: number
+  name: string
+  provider: string
+  external_repo_id: string
+  url: string
+}
+
+interface AikidoIssue {
+  group_id: number
+  severity: AikidoSeverity
+  type: string
+  code_repo_id: number
+  code_repo_name: string
+  cve_id: string | null
+  affected_package: string | null
+}
+
+interface TokenResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+}
+
+interface AikidoServiceProps {
+  config: Config
+  credentialsProvider: AikidoCredentialsProvider
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export class AikidoService {
+  private config: Config
+  private credentialsProvider: AikidoCredentialsProvider
+  private accessToken: string | null = null
+
+  public constructor(props: AikidoServiceProps) {
+    this.config = props.config
+    this.credentialsProvider = props.credentialsProvider
+  }
+
+  private async getAccessToken(forceRefresh = false): Promise<string> {
+    if (this.accessToken && !forceRefresh) {
+      return this.accessToken
+    }
+
+    const { clientId, clientSecret }: AikidoCredentials =
+      await this.credentialsProvider.getCredentials()
+    const basic = Buffer.from(`${clientId}:${clientSecret}`, "utf8").toString(
+      "base64",
+    )
+
+    const response = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basic}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: "grant_type=client_credentials",
+      agent: this.config.agent,
+    } as FetchOptions)
+
+    if (!response.ok) {
+      throw new Error(
+        `Aikido token exchange failed (${response.status}): ${await response.text()}`,
+      )
+    }
+
+    const token = (await response.json()) as TokenResponse
+    this.accessToken = token.access_token
+    return this.accessToken
+  }
+
+  /**
+   * GET an Aikido API path. Honors the 20 req/min rate limit by respecting the
+   * `Retry-After` header on 429 (with exponential-backoff fallback), and
+   * re-authenticates once on 401.
+   */
+  private async apiGet<T>(path: string): Promise<T> {
+    let reauthed = false
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const token = await this.getAccessToken()
+      const response = await fetch(`${API_BASE}${path}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        agent: this.config.agent,
+      } as FetchOptions)
+
+      if (response.status === 401 && !reauthed) {
+        reauthed = true
+        await this.getAccessToken(true)
+        continue
+      }
+
+      if (response.status === 429) {
+        const retryAfter = Number(response.headers.get("retry-after"))
+        const waitSeconds = Number.isFinite(retryAfter)
+          ? retryAfter
+          : 2 ** attempt
+        process.stderr.write(
+          `Aikido rate limited on ${path}, waiting ${waitSeconds}s\n`,
+        )
+        await sleep(waitSeconds * 1000)
+        continue
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `Response from Aikido not OK (${response.status}) for ${path}: ${await response.text()}`,
+        )
+      }
+
+      return (await response.json()) as T
+    }
+
+    throw new Error(`Aikido request to ${path} exhausted retries`)
+  }
+
+  private async listCodeRepos(): Promise<AikidoCodeRepo[]> {
+    const repos: AikidoCodeRepo[] = []
+    for (let page = 0; ; page++) {
+      const batch = await this.apiGet<AikidoCodeRepo[]>(
+        `/repositories/code?page=${page}&per_page=${REPOS_PER_PAGE}&include_inactive=false`,
+      )
+      repos.push(...batch)
+      if (batch.length < REPOS_PER_PAGE) break
+    }
+    return repos
+  }
+
+  private async exportOpenIssues(): Promise<AikidoIssue[]> {
+    const issues: AikidoIssue[] = []
+    for (let page = 0; ; page++) {
+      const batch = await this.apiGet<AikidoIssue[]>(
+        `/issues/export?format=json&filter_status=open&page=${page}&per_page=${ISSUES_PER_PAGE}`,
+      )
+      issues.push(...batch)
+      if (batch.length < ISSUES_PER_PAGE) break
+    }
+    return issues
+  }
+
+  /**
+   * Fetch all onboarded repos and open issues, then aggregate into per-repo
+   * metrics. Issues are filtered to security-relevant `ISSUE_TYPES` and
+   * deduplicated by `group_id` (keeping the highest severity).
+   *
+   * Returns a map keyed by lowercased repo name (both the Aikido repo name and
+   * the repo slug from its URL, so lookups by GitHub repo name resolve).
+   */
+  public async getIssueGroupsByRepo(): Promise<Map<string, AikidoMetrics>> {
+    const [repos, issues] = await Promise.all([
+      this.listCodeRepos(),
+      this.exportOpenIssues(),
+    ])
+
+    const groupsByRepoId = groupIssuesByRepo(issues)
+
+    const byName = new Map<string, AikidoMetrics>()
+    for (const repo of repos) {
+      const metrics: AikidoMetrics = {
+        enabled: true,
+        issueGroups: groupsByRepoId.get(repo.id) ?? [],
+      }
+      for (const key of repoLookupKeys(repo)) {
+        byName.set(key, metrics)
+      }
+    }
+    return byName
+  }
+}
+
+/** Candidate lookup keys for an Aikido repo: its name and its URL repo slug. */
+function repoLookupKeys(repo: AikidoCodeRepo): string[] {
+  const keys = [repo.name.toLowerCase()]
+  const slug = repo.url.split("/").filter(Boolean).pop()
+  if (slug) keys.push(slug.toLowerCase())
+  return keys
+}
+
+function groupIssuesByRepo(
+  issues: AikidoIssue[],
+): Map<number, AikidoIssueGroup[]> {
+  // repoId -> groupId -> group (highest severity wins).
+  const perRepo = new Map<number, Map<number, AikidoIssueGroup>>()
+
+  for (const issue of issues) {
+    if (!ISSUE_TYPES.has(issue.type)) continue
+
+    let groups = perRepo.get(issue.code_repo_id)
+    if (!groups) {
+      groups = new Map()
+      perRepo.set(issue.code_repo_id, groups)
+    }
+
+    const candidate: AikidoIssueGroup = {
+      groupId: issue.group_id,
+      severity: issue.severity,
+      type: issue.type,
+      name: issue.cve_id ?? issue.affected_package ?? issue.type,
+    }
+
+    const existing = groups.get(issue.group_id)
+    if (
+      !existing ||
+      SEVERITY_RANK[candidate.severity] > SEVERITY_RANK[existing.severity]
+    ) {
+      groups.set(issue.group_id, candidate)
+    }
+  }
+
+  const result = new Map<number, AikidoIssueGroup[]>()
+  for (const [repoId, groups] of perRepo) {
+    result.set(repoId, [...groups.values()])
+  }
+  return result
+}
+
+interface CreateAikidoServiceProps {
+  config: Config
+  credentialsProvider?: AikidoCredentialsProvider
+}
+
+export function createAikidoService(
+  props: CreateAikidoServiceProps,
+): AikidoService {
+  return new AikidoService({
+    config: props.config,
+    credentialsProvider:
+      props.credentialsProvider ?? new AikidoCredentialsCliProvider(),
+  })
+}

--- a/packages/repo-collector/src/aikido/service.ts
+++ b/packages/repo-collector/src/aikido/service.ts
@@ -48,7 +48,6 @@ interface AikidoCodeRepo {
 }
 
 interface AikidoIssue {
-  id: number
   group_id: number
   severity: AikidoSeverity
   type: string
@@ -214,6 +213,7 @@ export class AikidoService {
     for (const repo of repos) {
       const metrics: AikidoMetrics = {
         enabled: true,
+        repoId: repo.id,
         issueGroups: groupsByRepoId.get(repo.id) ?? [],
         ignoredCount: ignoredByRepoId.get(repo.id) ?? 0,
       }
@@ -235,7 +235,6 @@ function repoLookupKeys(repo: AikidoCodeRepo): string[] {
 
 interface GroupAccumulator {
   groupId: number
-  issueId: number
   severity: AikidoSeverity
   type: string
   count: number
@@ -263,7 +262,6 @@ function groupIssuesByRepo(
     if (!existing) {
       groups.set(issue.group_id, {
         groupId: issue.group_id,
-        issueId: issue.id,
         severity: issue.severity,
         type: issue.type,
         count: 1,
@@ -275,7 +273,6 @@ function groupIssuesByRepo(
       existing.count += 1
       if (SEVERITY_RANK[issue.severity] > SEVERITY_RANK[existing.severity]) {
         existing.severity = issue.severity
-        existing.issueId = issue.id
       }
     }
   }
@@ -286,7 +283,6 @@ function groupIssuesByRepo(
       repoId,
       [...groups.values()].map((g) => ({
         groupId: g.groupId,
-        issueId: g.issueId,
         severity: g.severity,
         type: g.type,
         title: deriveTitle(g),

--- a/packages/repo-collector/src/aikido/token.ts
+++ b/packages/repo-collector/src/aikido/token.ts
@@ -1,0 +1,31 @@
+export interface AikidoCredentials {
+  clientId: string
+  clientSecret: string
+}
+
+/**
+ * Supplies the Aikido REST API client credentials (client id + secret). The
+ * short-lived access token exchange itself lives in `AikidoService`, mirroring
+ * how the SonarCloud service owns its request auth.
+ */
+export interface AikidoCredentialsProvider {
+  getCredentials(): Promise<AikidoCredentials>
+}
+
+/**
+ * Reads credentials from `AIKIDO_CLIENT_ID` / `AIKIDO_CLIENT_SECRET`, for local
+ * CLI runs. Mirrors `SonarCloudTokenCliProvider`.
+ */
+export class AikidoCredentialsCliProvider implements AikidoCredentialsProvider {
+  async getCredentials(): Promise<AikidoCredentials> {
+    const clientId = process.env.AIKIDO_CLIENT_ID
+    const clientSecret = process.env.AIKIDO_CLIENT_SECRET
+    if (!clientId || !clientSecret) {
+      console.error(
+        "Missing required environment variables: AIKIDO_CLIENT_ID and AIKIDO_CLIENT_SECRET",
+      )
+      process.exit(1)
+    }
+    return { clientId, clientSecret }
+  }
+}

--- a/packages/repo-collector/src/lambda.ts
+++ b/packages/repo-collector/src/lambda.ts
@@ -1,6 +1,7 @@
 import { SecretsManager } from "@aws-sdk/client-secrets-manager"
 import { Temporal } from "@js-temporal/polyfill"
 import type { Handler } from "aws-lambda"
+import type { AikidoCredentialsProvider } from "./aikido/token"
 import { isWorkingDay } from "./dates"
 import { loadGitHubAppProviderFromSecrets } from "./github/token"
 import {
@@ -50,6 +51,15 @@ async function getSonarCloudTokenProvider(): Promise<SonarCloudTokenProvider> {
   }
 }
 
+async function getAikidoCredentialsProvider(): Promise<AikidoCredentialsProvider> {
+  const aikidoApiSecretId = requireEnv("AIKIDO_API_SECRET_ID")
+  const { clientId, clientSecret } = await getSecretValue(aikidoApiSecretId)
+
+  return {
+    getCredentials: () => Promise.resolve({ clientId, clientSecret }),
+  }
+}
+
 // noinspection JSUnusedGlobalSymbols
 export const collectHandler: Handler = async () => {
   console.log("Collecting data for aggregation")
@@ -65,6 +75,7 @@ export const collectHandler: Handler = async () => {
     snapshotsRepository,
     await loadGitHubAppProviderFromSecrets(),
     await getSonarCloudTokenProvider(),
+    await getAikidoCredentialsProvider(),
   )
   console.log("Done.")
 }

--- a/packages/repo-collector/src/reporter/reporter.test.ts
+++ b/packages/repo-collector/src/reporter/reporter.test.ts
@@ -33,11 +33,13 @@ function repo(overrides: Partial<SnapshotMetrics> = {}): SnapshotMetrics {
 function aikidoGroups(severities: AikidoSeverity[]): SnapshotMetrics["aikido"] {
   return {
     enabled: true,
+    ignoredCount: 0,
     issueGroups: severities.map((severity, i) => ({
       groupId: i + 1,
+      issueId: (i + 1) * 10,
       severity,
       type: "open_source",
-      name: `pkg-${i}`,
+      title: `pkg-${i}`,
     })),
   }
 }

--- a/packages/repo-collector/src/reporter/reporter.test.ts
+++ b/packages/repo-collector/src/reporter/reporter.test.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@js-temporal/polyfill"
 import type {
-  GitHubVulnerabilityAlert,
+  AikidoSeverity,
   SnapshotData,
   SnapshotMetrics,
 } from "@liflig/repo-metrics-repo-collector-types"
@@ -30,128 +30,53 @@ function repo(overrides: Partial<SnapshotMetrics> = {}): SnapshotMetrics {
   }
 }
 
-function ghAlert(
-  severity: GitHubVulnerabilityAlert["securityAdvisory"] extends null
-    ? never
-    : NonNullable<GitHubVulnerabilityAlert["securityAdvisory"]>["severity"],
-): GitHubVulnerabilityAlert {
+function aikidoGroups(severities: AikidoSeverity[]): SnapshotMetrics["aikido"] {
   return {
-    state: "OPEN",
-    dismissReason: null,
-    vulnerableManifestFilename: "",
-    vulnerableManifestPath: "",
-    vulnerableRequirements: null,
-    securityAdvisory: {
-      description: "",
-      identifiers: [],
-      references: [],
+    enabled: true,
+    issueGroups: severities.map((severity, i) => ({
+      groupId: i + 1,
       severity,
-    },
-    securityVulnerability: null,
+      type: "open_source",
+      name: `pkg-${i}`,
+    })),
   }
 }
 
-function repoWithGhVulns(
-  overrides: Partial<SnapshotMetrics> & {
-    severities: ("CRITICAL" | "HIGH" | "MODERATE" | "LOW")[]
-  },
+function repoWithAikidoVulns(
+  overrides: Partial<SnapshotMetrics> & { severities: AikidoSeverity[] },
 ): SnapshotMetrics {
   const { severities, ...rest } = overrides
-  return repo({
-    ...rest,
-    github: {
-      orgName: "org",
-      repoName: "repo",
-      prs: [],
-      vulnerabilityAlerts: severities.map(ghAlert),
-      renovateDependencyDashboardIssue: null,
-    },
-  })
+  return repo({ ...rest, aikido: aikidoGroups(severities) })
 }
 
 describe("countSeveritiesForRepo", () => {
-  test("sums GitHub severities", () => {
+  test("sums Aikido severities", () => {
     const result = countSeveritiesForRepo(
-      repo({
-        github: {
-          orgName: "org",
-          repoName: "repo",
-          prs: [],
-          renovateDependencyDashboardIssue: null,
-          vulnerabilityAlerts: [
-            ghAlert("CRITICAL"),
-            ghAlert("HIGH"),
-            ghAlert("HIGH"),
-            ghAlert("MODERATE"),
-            ghAlert("MODERATE"),
-            ghAlert("MODERATE"),
-            ghAlert("LOW"),
-            ghAlert("LOW"),
-            ghAlert("LOW"),
-            ghAlert("LOW"),
-          ],
-        },
+      repoWithAikidoVulns({
+        severities: [
+          "critical",
+          "high",
+          "high",
+          "medium",
+          "medium",
+          "medium",
+          "low",
+          "low",
+          "low",
+          "low",
+        ],
       }),
     )
     expect(result).toStrictEqual({ critical: 1, high: 2, medium: 3, low: 4 })
   })
 
-  test("maps GitHub MODERATE to medium and ignores dismissed alerts", () => {
-    const result = countSeveritiesForRepo(
-      repo({
-        github: {
-          orgName: "org",
-          repoName: "repo",
-          prs: [],
-          renovateDependencyDashboardIssue: null,
-          vulnerabilityAlerts: [
-            {
-              state: "OPEN",
-              dismissReason: null,
-              vulnerableManifestFilename: "",
-              vulnerableManifestPath: "",
-              vulnerableRequirements: null,
-              securityAdvisory: {
-                description: "",
-                identifiers: [],
-                references: [],
-                severity: "CRITICAL",
-              },
-              securityVulnerability: null,
-            },
-            {
-              state: "OPEN",
-              dismissReason: null,
-              vulnerableManifestFilename: "",
-              vulnerableManifestPath: "",
-              vulnerableRequirements: null,
-              securityAdvisory: {
-                description: "",
-                identifiers: [],
-                references: [],
-                severity: "MODERATE",
-              },
-              securityVulnerability: null,
-            },
-            {
-              state: "DISMISSED",
-              dismissReason: "fix_started",
-              vulnerableManifestFilename: "",
-              vulnerableManifestPath: "",
-              vulnerableRequirements: null,
-              securityAdvisory: {
-                description: "",
-                identifiers: [],
-                references: [],
-                severity: "HIGH",
-              },
-              securityVulnerability: null,
-            },
-          ],
-        },
-      }),
-    )
-    expect(result).toStrictEqual({ critical: 1, high: 0, medium: 1, low: 0 })
+  test("treats missing Aikido data as no vulns", () => {
+    expect(countSeveritiesForRepo(repo())).toStrictEqual({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+    })
   })
 })
 
@@ -228,15 +153,15 @@ describe("buildReportData", () => {
     const snapshot: SnapshotData = {
       timestamp: now.toString(),
       metrics: [
-        repoWithGhVulns({
+        repoWithAikidoVulns({
           repoId: "org/zeta",
           responsible: "team-b",
-          severities: ["CRITICAL"],
+          severities: ["critical"],
         }),
-        repoWithGhVulns({
+        repoWithAikidoVulns({
           repoId: "org/alpha",
           responsible: "team-a",
-          severities: ["HIGH", "HIGH"],
+          severities: ["high", "high"],
         }),
         repo({ repoId: "org/clean", responsible: "team-c" }),
       ],
@@ -262,26 +187,26 @@ describe("buildPerTeamMessages", () => {
     const snapshot: SnapshotData = {
       timestamp: now.toString(),
       metrics: [
-        repoWithGhVulns({
+        repoWithAikidoVulns({
           repoId: "org/a",
           responsible: "team-a",
           severities: [
-            "CRITICAL",
-            "HIGH",
-            "HIGH",
-            "MODERATE",
-            "MODERATE",
-            "MODERATE",
-            "LOW",
-            "LOW",
-            "LOW",
-            "LOW",
+            "critical",
+            "high",
+            "high",
+            "medium",
+            "medium",
+            "medium",
+            "low",
+            "low",
+            "low",
+            "low",
           ],
         }),
-        repoWithGhVulns({
+        repoWithAikidoVulns({
           repoId: "org/b",
           responsible: "team-b",
-          severities: ["HIGH"],
+          severities: ["high"],
         }),
       ],
     }
@@ -314,15 +239,15 @@ describe("buildPerTeamMessages", () => {
     const snapshot: SnapshotData = {
       timestamp: now.toString(),
       metrics: [
-        repoWithGhVulns({
+        repoWithAikidoVulns({
           repoId: "org/alpha",
           responsible: "team-a",
-          severities: ["HIGH", "HIGH", "MODERATE", "MODERATE", "MODERATE"],
+          severities: ["high", "high", "medium", "medium", "medium"],
         }),
-        repoWithGhVulns({
+        repoWithAikidoVulns({
           repoId: "org/beta",
           responsible: "team-a",
-          severities: ["CRITICAL"],
+          severities: ["critical"],
         }),
         // No vulns — must not appear as a table row.
         repo({ repoId: "org/clean", responsible: "team-a" }),
@@ -334,8 +259,7 @@ describe("buildPerTeamMessages", () => {
     )
 
     const table = message.blocks.find((b) => b.type === "table")
-    if (!table || table.type !== "table")
-      throw new Error("expected a table block")
+    if (table?.type !== "table") throw new Error("expected a table block")
 
     const rawText = (cell: unknown): string | undefined =>
       typeof cell === "object" &&
@@ -373,16 +297,17 @@ describe("buildPerTeamMessages", () => {
     const snapshot: SnapshotData = {
       timestamp: now.toString(),
       metrics: [
-        repo({
+        repoWithAikidoVulns({
           repoId: "liflig/liflig-logging",
           github: {
             orgName: "liflig",
             repoName: "liflig-logging",
             prs: [],
-            vulnerabilityAlerts: [ghAlert("HIGH")],
+            vulnerabilityAlerts: [],
             renovateDependencyDashboardIssue: null,
           },
           responsible: "team-a",
+          severities: ["high"],
         }),
       ],
     }
@@ -392,7 +317,7 @@ describe("buildPerTeamMessages", () => {
     )
     const json = JSON.stringify(message)
     expect(json).toContain(
-      "https://example/?filterRepoName=liflig-logging&showVulGithubList=true",
+      "https://example/?filterRepoName=liflig-logging&showVulAikidoList=true",
     )
     expect(json).toContain('"text":"liflig-logging"')
     expect(json).not.toContain('"text":"liflig/liflig-logging"')

--- a/packages/repo-collector/src/reporter/reporter.test.ts
+++ b/packages/repo-collector/src/reporter/reporter.test.ts
@@ -33,10 +33,10 @@ function repo(overrides: Partial<SnapshotMetrics> = {}): SnapshotMetrics {
 function aikidoGroups(severities: AikidoSeverity[]): SnapshotMetrics["aikido"] {
   return {
     enabled: true,
+    repoId: 1,
     ignoredCount: 0,
     issueGroups: severities.map((severity, i) => ({
       groupId: i + 1,
-      issueId: (i + 1) * 10,
       severity,
       type: "open_source",
       title: `pkg-${i}`,

--- a/packages/repo-collector/src/reporter/reporter.ts
+++ b/packages/repo-collector/src/reporter/reporter.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@js-temporal/polyfill"
 import type {
-  GitHubVulnerabilityAlert,
+  AikidoIssueGroup,
   SnapshotData,
   SnapshotMetrics,
 } from "@liflig/repo-metrics-repo-collector-types"
@@ -71,26 +71,16 @@ function totalOf(s: SeverityCounts): number {
   return s.critical + s.high + s.medium + s.low
 }
 
-function githubSeverities(alerts: GitHubVulnerabilityAlert[]): SeverityCounts {
+// Aikido is the vulnerability source for the report. Its severities map 1:1 to
+// our SeverityCounts keys.
+export function countSeveritiesForRepo(metrics: {
+  aikido?: { issueGroups: AikidoIssueGroup[] }
+}): SeverityCounts {
   const counts = zeroSeverities()
-  for (const alert of alerts) {
-    const open =
-      alert.state == null ? alert.dismissReason == null : alert.state === "OPEN"
-    if (!open) continue
-    const sev = alert.securityAdvisory?.severity
-    if (sev === "CRITICAL") counts.critical += 1
-    else if (sev === "HIGH") counts.high += 1
-    else if (sev === "MODERATE") counts.medium += 1
-    else if (sev === "LOW") counts.low += 1
-    else counts.medium += 1
+  for (const group of metrics.aikido?.issueGroups ?? []) {
+    counts[group.severity] += 1
   }
   return counts
-}
-
-export function countSeveritiesForRepo(metrics: {
-  github: { vulnerabilityAlerts: GitHubVulnerabilityAlert[] }
-}): SeverityCounts {
-  return githubSeverities(metrics.github.vulnerabilityAlerts)
 }
 
 function daysBetween(from: Temporal.Instant, to: Temporal.Instant): number {
@@ -305,7 +295,7 @@ function buildVulnTable(
   const bodyRows = items.map((e) => {
     const url = webappUrl(webappBaseUrl, {
       filterRepoName: e.repoName,
-      showVulGithubList: "true",
+      showVulAikidoList: "true",
     })
     return [
       repoLinkCell(e.repoName, url),

--- a/packages/repo-collector/src/snapshots/collect.ts
+++ b/packages/repo-collector/src/snapshots/collect.ts
@@ -1,9 +1,12 @@
 import { Temporal } from "@js-temporal/polyfill"
 import type {
+  AikidoMetrics,
   SnapshotData,
   SnapshotMetrics,
 } from "@liflig/repo-metrics-repo-collector-types"
 import { groupBy } from "lodash-es"
+import * as aikido from "../aikido/service"
+import type { AikidoCredentialsProvider } from "../aikido/token"
 import { CacheProvider } from "../cache"
 import { Config } from "../config"
 import * as definition from "../definition/definition"
@@ -15,9 +18,12 @@ import type { SonarCloudTokenProvider } from "../sonarcloud/token"
 import { GithubDefinitionProvider } from "./definition-provider"
 import type { SnapshotsRepository } from "./snapshots-repository"
 
+const AIKIDO_DISABLED: AikidoMetrics = { enabled: false, issueGroups: [] }
+
 async function createSnapshotData(
   githubService: github.GitHubService,
   sonarCloudService: sonarCloud.SonarCloudService,
+  aikidoByRepo: Map<string, AikidoMetrics>,
   repos: GetReposResponse[],
   systemsMapping: Map<string, { customer: string; system: string }>,
 ): Promise<SnapshotData> {
@@ -80,6 +86,8 @@ async function createSnapshotData(
         vulnerabilityAlerts: await repo.githubVulnerabilityAlerts,
       },
       sonarCloud: await repo.sonarCloudMetrics,
+      aikido:
+        aikidoByRepo.get(repo.repo.repo.name.toLowerCase()) ?? AIKIDO_DISABLED,
     })
   }
 
@@ -101,6 +109,7 @@ export async function collect(
   snapshotsRepository: SnapshotsRepository,
   githubTokenProvider?: GitHubAuthProvider,
   sonarCloudTokenProvider?: SonarCloudTokenProvider,
+  aikidoCredentialsProvider?: AikidoCredentialsProvider,
 ) {
   const config = new Config()
   console.log(`Working directory: ${config.cwd}`)
@@ -120,12 +129,34 @@ export async function collect(
     tokenProvider: sonarCloudTokenProvider,
   })
 
+  const aikidoService = aikido.createAikidoService({
+    config,
+    credentialsProvider: aikidoCredentialsProvider,
+  })
+
   const snapshotData = await createSnapshotData(
     githubService,
     sonarCloudService,
+    await fetchAikidoByRepo(aikidoService),
     await definitionProvider.getRepos(),
     await definitionProvider.getSystemsMapping(),
   )
 
   await snapshotsRepository.store(snapshotData)
+}
+
+/**
+ * Aikido data is fetched once for the whole workspace (few API calls, tight
+ * rate limit). A total failure degrades to empty rather than failing the whole
+ * snapshot, since Aikido is one of several sources.
+ */
+async function fetchAikidoByRepo(
+  aikidoService: aikido.AikidoService,
+): Promise<Map<string, AikidoMetrics>> {
+  try {
+    return await aikidoService.getIssueGroupsByRepo()
+  } catch (e) {
+    console.error("Failed to fetch Aikido data, continuing without it:", e)
+    return new Map()
+  }
 }

--- a/packages/repo-collector/src/snapshots/collect.ts
+++ b/packages/repo-collector/src/snapshots/collect.ts
@@ -20,6 +20,7 @@ import type { SnapshotsRepository } from "./snapshots-repository"
 
 const AIKIDO_DISABLED: AikidoMetrics = {
   enabled: false,
+  repoId: null,
   issueGroups: [],
   ignoredCount: 0,
 }

--- a/packages/repo-collector/src/snapshots/collect.ts
+++ b/packages/repo-collector/src/snapshots/collect.ts
@@ -18,7 +18,11 @@ import type { SonarCloudTokenProvider } from "../sonarcloud/token"
 import { GithubDefinitionProvider } from "./definition-provider"
 import type { SnapshotsRepository } from "./snapshots-repository"
 
-const AIKIDO_DISABLED: AikidoMetrics = { enabled: false, issueGroups: [] }
+const AIKIDO_DISABLED: AikidoMetrics = {
+  enabled: false,
+  issueGroups: [],
+  ignoredCount: 0,
+}
 
 async function createSnapshotData(
   githubService: github.GitHubService,

--- a/packages/repo-collector/src/webapp/webapp.ts
+++ b/packages/repo-collector/src/webapp/webapp.ts
@@ -77,10 +77,12 @@ function mapSnapshotMetricToWebappMetrics(
     },
     aikido: {
       enabled: snapshotMetrics.aikido?.enabled ?? false,
+      ignoredCount: snapshotMetrics.aikido?.ignoredCount ?? 0,
       issues: (snapshotMetrics.aikido?.issueGroups ?? []).map((group) => ({
+        issueId: group.issueId,
         severity: group.severity,
         type: group.type,
-        name: group.name,
+        title: group.title,
       })),
     },
   }

--- a/packages/repo-collector/src/webapp/webapp.ts
+++ b/packages/repo-collector/src/webapp/webapp.ts
@@ -77,9 +77,10 @@ function mapSnapshotMetricToWebappMetrics(
     },
     aikido: {
       enabled: snapshotMetrics.aikido?.enabled ?? false,
+      repoId: snapshotMetrics.aikido?.repoId ?? null,
       ignoredCount: snapshotMetrics.aikido?.ignoredCount ?? 0,
       issues: (snapshotMetrics.aikido?.issueGroups ?? []).map((group) => ({
-        issueId: group.issueId,
+        groupId: group.groupId,
         severity: group.severity,
         type: group.type,
         title: group.title,

--- a/packages/repo-collector/src/webapp/webapp.ts
+++ b/packages/repo-collector/src/webapp/webapp.ts
@@ -75,6 +75,14 @@ function mapSnapshotMetricToWebappMetrics(
         (el) => el.metric === "coverage",
       )?.value,
     },
+    aikido: {
+      enabled: snapshotMetrics.aikido?.enabled ?? false,
+      issues: (snapshotMetrics.aikido?.issueGroups ?? []).map((group) => ({
+        severity: group.severity,
+        type: group.type,
+        name: group.name,
+      })),
+    },
   }
 }
 

--- a/packages/webapp/src/DataGroup.tsx
+++ b/packages/webapp/src/DataGroup.tsx
@@ -9,6 +9,7 @@ interface Props {
   showBotPrList: boolean
   showDepList: boolean
   showVulGithubList: boolean
+  showVulAikidoList: boolean
   showOrgName: boolean
   sortByRenovateDays: boolean
   filterRepoName: string
@@ -22,6 +23,7 @@ export const DataGroup: React.FC<Props> = ({
   showBotPrList,
   showDepList,
   showVulGithubList,
+  showVulAikidoList,
   showOrgName,
   sortByRenovateDays,
   filterRepoName,
@@ -63,6 +65,7 @@ export const DataGroup: React.FC<Props> = ({
             showBotPrList,
             showDepList,
             showVulGithubList,
+            showVulAikidoList,
             showOrgName,
             showRenovateDays: sortByRenovateDays,
             filterRepoName,

--- a/packages/webapp/src/DataList.tsx
+++ b/packages/webapp/src/DataList.tsx
@@ -386,6 +386,12 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
               Sårbarheter (GitHub)
             </Checkbox>
             <Checkbox
+              checked={state.showVulAikidoList}
+              onCheck={createOnCheckHandler("showVulAikidoList")}
+            >
+              Sårbarheter (Aikido)
+            </Checkbox>
+            <Checkbox
               checked={state.showOrgName}
               onCheck={createOnCheckHandler("showOrgName")}
             >
@@ -465,6 +471,7 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
               showBotPrList={state.showBotPrList}
               showDepList={state.showDepList}
               showVulGithubList={state.showVulGithubList}
+              showVulAikidoList={state.showVulAikidoList}
               showOrgName={state.showOrgName}
               sortByRenovateDays={state.sortByRenovateDays}
               filterRepoName={state.filterRepoName}

--- a/packages/webapp/src/Repo.tsx
+++ b/packages/webapp/src/Repo.tsx
@@ -228,43 +228,66 @@ export const repoColumns = (props: {
       subheader: "Aikido",
       headerIcon: <SecurityIcon />,
       width: "9%",
-      sortOn: (repo) => repo.metrics.aikido.issues.length,
+      sortOn: (repo) => aikidoSortValue(repo.metrics.aikido.issues),
       render: (repo, isExpanded) => {
         const aikido = repo.metrics.aikido
         if (!aikido.enabled) {
           return <span className="state-missing" title="Ingen data">—</span>
         }
-        if (aikido.issues.length === 0) {
+        if (aikido.issues.length === 0 && aikido.ignoredCount === 0) {
           return <span className="state-ok">Ingen</span>
         }
+
+        const summary = (
+          <AikidoSeverityCounts
+            issues={aikido.issues}
+            ignoredCount={aikido.ignoredCount}
+          />
+        )
+
         const hasVulSearch = filterVulName !== ""
         const matchingIssues = hasVulSearch
           ? aikido.issues.filter((i) =>
-              i.name.toLowerCase().includes(filterVulName.toLowerCase()),
+              i.title.toLowerCase().includes(filterVulName.toLowerCase()),
             )
           : []
-        const showDetails = showVulAikidoList || isExpanded || matchingIssues.length > 0
+        const showDetails =
+          showVulAikidoList || isExpanded || matchingIssues.length > 0
         if (!showDetails) {
-          return <b>{aikido.issues.length}</b>
+          return summary
         }
-        const issuesToGroup = showVulAikidoList || isExpanded ? aikido.issues : matchingIssues
-        const grouped = groupAikidoByName(issuesToGroup)
+
+        const listed =
+          showVulAikidoList || isExpanded ? aikido.issues : matchingIssues
+        const sorted = [...listed].sort(
+          (a, b) =>
+            AIKIDO_SEVERITY_ORDER.indexOf(a.severity) -
+              AIKIDO_SEVERITY_ORDER.indexOf(b.severity) ||
+            a.title.localeCompare(b.title),
+        )
         return (
-          <ul className="detail-list">
-            {grouped.map((group, idx) => (
-              <li key={idx} className="detail-item">
-                <span className="detail-index">{idx + 1}</span>
-                <Highlight text={group.name} search={filterVulName} />
-                {group.count > 1 && (
-                  <span className="detail-meta">&times;{group.count}</span>
-                )}
-                <span className="detail-meta"> {group.type}</span>
-                <span className={`detail-severity severity-${group.highestSeverity}`}>
-                  {group.highestSeverity}
-                </span>
-              </li>
-            ))}
-          </ul>
+          <>
+            {summary}
+            <ul className="detail-list">
+              {sorted.map((issue, idx) => (
+                <li key={idx} className="detail-item">
+                  <span className="detail-index">{idx + 1}</span>
+                  <a
+                    href={`${AIKIDO_ISSUE_URL}${issue.issueId}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <Highlight text={issue.title} search={filterVulName} />
+                  </a>
+                  <span
+                    className={`detail-severity severity-${issue.severity}`}
+                  >
+                    {issue.severity}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </>
         )
       },
     },
@@ -328,44 +351,65 @@ const AIKIDO_SEVERITY_ORDER: AikidoSeverity[] = [
   "low",
 ]
 
-function groupAikidoByName(
-  issues: { name: string; type: string; severity: AikidoSeverity }[],
-) {
-  const map = new Map<
-    string,
-    { count: number; type: string; highestSeverity: AikidoSeverity }
-  >()
-  for (const issue of issues) {
-    const existing = map.get(issue.name)
-    if (existing) {
-      existing.count++
-      if (
-        AIKIDO_SEVERITY_ORDER.indexOf(issue.severity) <
-        AIKIDO_SEVERITY_ORDER.indexOf(existing.highestSeverity)
-      ) {
-        existing.highestSeverity = issue.severity
-      }
-    } else {
-      map.set(issue.name, {
-        count: 1,
-        type: issue.type,
-        highestSeverity: issue.severity,
-      })
-    }
+// Deep link to a single issue in the Aikido dashboard (queue sidebar).
+const AIKIDO_ISSUE_URL = "https://app.aikido.dev/queue?sidebarIssue="
+
+type AikidoIssue = Metrics["aikido"]["issues"][number]
+
+function aikidoSeverityBuckets(issues: AikidoIssue[]): Record<AikidoSeverity, number> {
+  const counts: Record<AikidoSeverity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
   }
-  return [...map.entries()]
-    .map(([name, { count, type, highestSeverity }]) => ({
-      name,
-      count,
-      type,
-      highestSeverity,
-    }))
-    .sort(
-      (a, b) =>
-        AIKIDO_SEVERITY_ORDER.indexOf(a.highestSeverity) -
-          AIKIDO_SEVERITY_ORDER.indexOf(b.highestSeverity) ||
-        a.name.localeCompare(b.name),
-    )
+  for (const issue of issues) counts[issue.severity]++
+  return counts
+}
+
+// Severity-weighted sort key so critical-heavy repos rank above low-severity ones.
+function aikidoSortValue(issues: AikidoIssue[]): number {
+  const c = aikidoSeverityBuckets(issues)
+  return c.critical * 1000 + c.high * 100 + c.medium * 10 + c.low
+}
+
+const AIKIDO_COUNT_META: {
+  key: AikidoSeverity
+  cls: string
+  label: string
+}[] = [
+  { key: "critical", cls: "sev-c", label: "Kritisk" },
+  { key: "high", cls: "sev-h", label: "Høy" },
+  { key: "medium", cls: "sev-m", label: "Medium" },
+  { key: "low", cls: "sev-l", label: "Lav" },
+]
+
+// Colorized per-severity counts (critical/high/medium/low) plus a muted count
+// of ignored issues, mirroring how Aikido presents a repo's issues.
+function AikidoSeverityCounts({
+  issues,
+  ignoredCount,
+}: {
+  issues: AikidoIssue[]
+  ignoredCount: number
+}) {
+  const counts = aikidoSeverityBuckets(issues)
+  return (
+    <span className="aikido-counts">
+      {AIKIDO_COUNT_META.map((meta) =>
+        counts[meta.key] > 0 ? (
+          <span key={meta.key} className={meta.cls} title={meta.label}>
+            {counts[meta.key]}
+          </span>
+        ) : null,
+      )}
+      {ignoredCount > 0 && (
+        <span className="sev-i" title="Ignorert">
+          {ignoredCount}
+        </span>
+      )}
+    </span>
+  )
 }
 
 export function isActionableRepo(repo: Metrics): boolean {

--- a/packages/webapp/src/Repo.tsx
+++ b/packages/webapp/src/Repo.tsx
@@ -273,7 +273,7 @@ export const repoColumns = (props: {
                 <li key={idx} className="detail-item">
                   <span className="detail-index">{idx + 1}</span>
                   <a
-                    href={`${AIKIDO_ISSUE_URL}${issue.issueId}`}
+                    href={aikidoIssueUrl(aikido.repoId, issue.groupId)}
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -351,8 +351,13 @@ const AIKIDO_SEVERITY_ORDER: AikidoSeverity[] = [
   "low",
 ]
 
-// Deep link to a single issue in the Aikido dashboard (queue sidebar).
-const AIKIDO_ISSUE_URL = "https://app.aikido.dev/queue?sidebarIssue="
+// Deep link to an issue group in the Aikido dashboard. Prefer the repo-scoped
+// view (opens the issue in the repo's detail page); fall back to the queue.
+function aikidoIssueUrl(repoId: number | null, groupId: number): string {
+  return repoId != null
+    ? `https://app.aikido.dev/repositories/${repoId}?sidebarIssue=${groupId}`
+    : `https://app.aikido.dev/queue?sidebarIssue=${groupId}`
+}
 
 type AikidoIssue = Metrics["aikido"]["issues"][number]
 

--- a/packages/webapp/src/Repo.tsx
+++ b/packages/webapp/src/Repo.tsx
@@ -1,4 +1,8 @@
-import type { Metrics, Repo } from "@liflig/repo-metrics-repo-collector-types"
+import type {
+  AikidoSeverity,
+  Metrics,
+  Repo,
+} from "@liflig/repo-metrics-repo-collector-types"
 import type * as React from "react"
 import { Highlight } from "./Highlight"
 import { GitHubIcon, PrIcon, RenovateIcon, SecurityIcon, SonarCloudIcon } from "./Icons"
@@ -11,6 +15,7 @@ export const repoColumns = (props: {
   showBotPrList: boolean
   showDepList: boolean
   showVulGithubList: boolean
+  showVulAikidoList: boolean
   showOrgName: boolean
   showRenovateDays: boolean
   filterRepoName: string
@@ -22,6 +27,7 @@ export const repoColumns = (props: {
     showBotPrList,
     showDepList,
     showVulGithubList,
+    showVulAikidoList,
     showOrgName,
     showRenovateDays,
     filterRepoName,
@@ -220,10 +226,47 @@ export const repoColumns = (props: {
     {
       header: "Sårbarheter",
       subheader: "Aikido",
-      width: "7%",
-      render: (_repo, _isExpanded) => (
-        <span className="state-missing" title="Ingen data">—</span>
-      ),
+      headerIcon: <SecurityIcon />,
+      width: "9%",
+      sortOn: (repo) => repo.metrics.aikido.issues.length,
+      render: (repo, isExpanded) => {
+        const aikido = repo.metrics.aikido
+        if (!aikido.enabled) {
+          return <span className="state-missing" title="Ingen data">—</span>
+        }
+        if (aikido.issues.length === 0) {
+          return <span className="state-ok">Ingen</span>
+        }
+        const hasVulSearch = filterVulName !== ""
+        const matchingIssues = hasVulSearch
+          ? aikido.issues.filter((i) =>
+              i.name.toLowerCase().includes(filterVulName.toLowerCase()),
+            )
+          : []
+        const showDetails = showVulAikidoList || isExpanded || matchingIssues.length > 0
+        if (!showDetails) {
+          return <b>{aikido.issues.length}</b>
+        }
+        const issuesToGroup = showVulAikidoList || isExpanded ? aikido.issues : matchingIssues
+        const grouped = groupAikidoByName(issuesToGroup)
+        return (
+          <ul className="detail-list">
+            {grouped.map((group, idx) => (
+              <li key={idx} className="detail-item">
+                <span className="detail-index">{idx + 1}</span>
+                <Highlight text={group.name} search={filterVulName} />
+                {group.count > 1 && (
+                  <span className="detail-meta">&times;{group.count}</span>
+                )}
+                <span className="detail-meta"> {group.type}</span>
+                <span className={`detail-severity severity-${group.highestSeverity}`}>
+                  {group.highestSeverity}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )
+      },
     },
     {
       header: "Testdekning",
@@ -276,6 +319,53 @@ function groupVulnsByPackage(
       const bi = b.highestSeverity ? SEVERITY_ORDER.indexOf(b.highestSeverity) : 999
       return ai - bi || a.packageName.localeCompare(b.packageName)
     })
+}
+
+const AIKIDO_SEVERITY_ORDER: AikidoSeverity[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+]
+
+function groupAikidoByName(
+  issues: { name: string; type: string; severity: AikidoSeverity }[],
+) {
+  const map = new Map<
+    string,
+    { count: number; type: string; highestSeverity: AikidoSeverity }
+  >()
+  for (const issue of issues) {
+    const existing = map.get(issue.name)
+    if (existing) {
+      existing.count++
+      if (
+        AIKIDO_SEVERITY_ORDER.indexOf(issue.severity) <
+        AIKIDO_SEVERITY_ORDER.indexOf(existing.highestSeverity)
+      ) {
+        existing.highestSeverity = issue.severity
+      }
+    } else {
+      map.set(issue.name, {
+        count: 1,
+        type: issue.type,
+        highestSeverity: issue.severity,
+      })
+    }
+  }
+  return [...map.entries()]
+    .map(([name, { count, type, highestSeverity }]) => ({
+      name,
+      count,
+      type,
+      highestSeverity,
+    }))
+    .sort(
+      (a, b) =>
+        AIKIDO_SEVERITY_ORDER.indexOf(a.highestSeverity) -
+          AIKIDO_SEVERITY_ORDER.indexOf(b.highestSeverity) ||
+        a.name.localeCompare(b.name),
+    )
 }
 
 export function isActionableRepo(repo: Metrics): boolean {

--- a/packages/webapp/src/filter.ts
+++ b/packages/webapp/src/filter.ts
@@ -9,6 +9,7 @@ export interface Filter
   showBotPrList: boolean
   showDepList: boolean
   showVulGithubList: boolean
+  showVulAikidoList: boolean
   showOrgName: boolean
   showOnlyWithPrs: boolean
   showOnlyWithBotPrs: boolean
@@ -26,6 +27,7 @@ export const defaultValues: Filter = {
   showBotPrList: false,
   showDepList: false,
   showVulGithubList: false,
+  showVulAikidoList: false,
   showOrgName: false,
   showOnlyWithPrs: false,
   showOnlyWithBotPrs: false,

--- a/packages/webapp/src/styles/main.css
+++ b/packages/webapp/src/styles/main.css
@@ -325,6 +325,19 @@ td:hover .renovate-logs-link {
 .severity-medium { background: var(--color-badge-pr-bg); color: var(--color-warning); }
 .severity-low { background: var(--color-secondary); color: var(--color-mute); }
 
+/* Aikido per-severity count breakdown */
+.aikido-counts {
+  display: inline-flex;
+  gap: 6px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.aikido-counts .sev-c { color: var(--color-sev-critical); }
+.aikido-counts .sev-h { color: var(--color-sev-high); }
+.aikido-counts .sev-m { color: var(--color-sev-medium); }
+.aikido-counts .sev-l { color: var(--color-sev-low); }
+.aikido-counts .sev-i { color: var(--color-sev-ignored); }
+
 /* Aikido project links in detail mode */
 .aikido-project-list {
   list-style: none;

--- a/packages/webapp/src/styles/variables.css
+++ b/packages/webapp/src/styles/variables.css
@@ -20,6 +20,13 @@
   --color-aikido-low: #6b7280;
   --color-aikido-zero: #b0b0b0;
 
+  /* Aikido per-severity count breakdown: red/yellow/blue/green + muted ignored */
+  --color-sev-critical: #b3261e;
+  --color-sev-high: #b7791f;
+  --color-sev-medium: #1d4ed8;
+  --color-sev-low: #15803d;
+  --color-sev-ignored: #8f8f8f;
+
   /* Coverage scale */
   --color-coverage-good: #1a7f37;
   --color-coverage-mid: #b45309;
@@ -59,6 +66,12 @@
   --color-aikido-medium: #f0a050;
   --color-aikido-low: #8b95a5;
   --color-aikido-zero: #666;
+
+  --color-sev-critical: #f08080;
+  --color-sev-high: #e0b050;
+  --color-sev-medium: #7ba0ff;
+  --color-sev-low: #6fdd8b;
+  --color-sev-ignored: #a0a0a0;
 
   --color-coverage-good: #6fdd8b;
   --color-coverage-mid: #f0a050;


### PR DESCRIPTION
Adds Aikido Security as the vulnerability source, alongside the existing GitHub Dependabot column.

## Collection
- OAuth client-credentials auth; token exchanged per run
- Fetch repos + open + ignored issues in ~4 calls (respects the 20 req/min limit)
- Aggregate per-repo severity counts; dedupe by issue group
- Include all security issue types (excludes `license`)
- Degrades to empty on failure rather than failing the snapshot

## Webapp
- Colorized per-severity breakdown (critical/high/medium/low) + muted ignored count
- Human-readable titles (package, rule, "N exposed secrets")
- Expanded issues deep-link to the repo-scoped Aikido view

## Reporter
- Slack vulnerability table now sourced from Aikido

## Infra
- `aikido-client` secret (client id + secret) in Secrets Manager, read by the collector

## Follow-up
- Once verified, make Aikido the sole source and drop the GitHub Dependabot column