### PR TITLE
fix: rename aikido secret to fix partial-ARN lookup failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ access token (OAuth2 client-credentials grant) on each run.
 
 Credentials live in AWS Secrets Manager (region `eu-west-1`, account `liflig-incubator`):
 
-- `/incub/repo-metrics/aikido-client` — JSON `{ clientId, clientSecret }`.
+- `/incub/repo-metrics/aikido-api` — JSON `{ clientId, clientSecret }`.
 
 To populate the secret, add the values in `packages/infrastructure/load-secrets.ts`'s
 flow and run:

--- a/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
+++ b/packages/infrastructure/__snapshots__/assembly-incub-repo-metrics-pipeline-Incubator/incubrepometricspipelineIncubatorincubrepometricsmainF01F78A2.template.json
@@ -2103,7 +2103,7 @@
                     {
                       "Ref": "AWS::Partition"
                     },
-                    ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-client-??????"
+                    ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-api-??????"
                   ]
                 ]
               }
@@ -2201,7 +2201,7 @@
                   {
                     "Ref": "AWS::Partition"
                   },
-                  ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-client"
+                  ":secretsmanager:eu-west-1:001112238813:secret:/incub/repo-metrics/aikido-api"
                 ]
               ]
             },

--- a/packages/infrastructure/load-secrets.ts
+++ b/packages/infrastructure/load-secrets.ts
@@ -35,7 +35,7 @@ const sonarCloudTokenSecret: loadSecrets.Secret = {
 }
 
 const aikidoClientSecret: loadSecrets.Secret = {
-  name: "aikido-client",
+  name: "aikido-api",
   description: "Aikido REST API client credentials (client id + secret)",
   type: "json",
   fields: [

--- a/packages/infrastructure/src/repo-metrics-stack.ts
+++ b/packages/infrastructure/src/repo-metrics-stack.ts
@@ -113,7 +113,7 @@ export class RepoMetricsStack extends cdk.Stack {
     const aikidoClientSecret = secretsmanager.Secret.fromSecretNameV2(
       this,
       "AikidoClientSecret",
-      "/incub/repo-metrics/aikido-client",
+      "/incub/repo-metrics/aikido-api",
     )
 
     const collectorFn = new lambda.Function(this, "Collector", {


### PR DESCRIPTION
The secret name `aikido-client` ends in a hyphen followed by exactly 6
characters (`client`), which Secrets Manager parses as a complete ARN's
random suffix. The collector passes the partial ARN (no suffix), so the
lookup resolves to a non-existent secret named `aikido` and the scoped
role gets AccessDenied on GetSecretValue.

Rename to `aikido-api` so the trailing segment is not 6 chars, keeping
the fromSecretNameV2 + partial-ARN convention working like the
github-app
and sonarcloud-token secrets.

Requires recreating the secret under the new name and re-entering the
clientId/clientSecret values before redeploy.
