### PR TITLE
refactor: remove GitHub vulnerability alerts integration

### DIFF
--- a/packages/repo-collector-types/src/index.ts
+++ b/packages/repo-collector-types/src/index.ts
@@ -1,7 +1,3 @@
-// This is based on VulnerabilityAlert from cals-cli but
-// duplicated so we can keep it persisted and have control
-// over changes.
-
 /**
  * A snapshot of all repos with embedded related details.
  *
@@ -34,7 +30,6 @@ export interface SnapshotMetrics {
       createdAt: string
       updatedAt: string
     }[]
-    vulnerabilityAlerts: GitHubVulnerabilityAlert[]
     renovateDependencyDashboardIssue: {
       number: number
       body: string
@@ -89,42 +84,6 @@ export interface AikidoIssueGroup {
   title: string
 }
 
-export interface GitHubVulnerabilityAlert {
-  dismissReason: string | null
-  state: "DISMISSED" | "FIXED" | "OPEN"
-  vulnerableManifestFilename: string
-  vulnerableManifestPath: string
-  vulnerableRequirements: string | null
-  securityAdvisory: {
-    description: string
-    identifiers: Array<{
-      type: string
-      value: string
-    }>
-    references: Array<{
-      url: string
-    }>
-    severity: "CRITICAL" | "HIGH" | "LOW" | "MODERATE"
-  } | null
-  securityVulnerability: {
-    package: {
-      name: string
-      ecosystem:
-        | "COMPOSER"
-        | "MAVEN"
-        | "NPM"
-        | "NUGET"
-        | "PIP"
-        | "RUBYGEMS"
-        | string
-    }
-    firstPatchedVersion: {
-      identifier: string
-    }
-    vulnerableVersionRange: string
-  } | null
-}
-
 /**
  * Data for webapp.
  */
@@ -159,11 +118,6 @@ export interface Metrics {
       author: string
       title: string
       createdAt: string
-    }[]
-    vulnerabilityAlerts: {
-      vulnerableManifestPath: string
-      severity?: "CRITICAL" | "HIGH" | "LOW" | "MODERATE"
-      packageName: string
     }[]
     availableUpdates?: {
       categoryName: string

--- a/packages/repo-collector/src/github/service.ts
+++ b/packages/repo-collector/src/github/service.ts
@@ -9,10 +9,7 @@ import type { CacheProvider } from "../cache"
 import type { Config } from "../config"
 import type { GitHubAuthProvider } from "./token"
 import { loadGitHubAppProviderFromSecrets } from "./token"
-import type {
-  RenovateDependencyDashboardIssue,
-  VulnerabilityAlert,
-} from "./types"
+import type { RenovateDependencyDashboardIssue } from "./types"
 
 type FetchOptions = RequestInit & { agent: Agent }
 
@@ -84,20 +81,6 @@ interface RenovateDependencyDashboardIssueQueryResult {
       }[]
     }
   }
-}
-
-interface VulnerabilityAlertsQueryResult {
-  repository: {
-    vulnerabilityAlerts: {
-      pageInfo: {
-        hasNextPage: boolean
-        endCursor: string | null
-      }
-      edges: Array<{
-        node: VulnerabilityAlert
-      }> | null
-    }
-  } | null
 }
 
 interface EtagCacheItem<T> {
@@ -341,76 +324,6 @@ export class GitHubService {
     }
 
     return pulls.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
-  }
-
-  /**
-   * Get the vulnerability alerts for a repository.
-   */
-  public async getVulnerabilityAlerts(
-    owner: string,
-    repo: string,
-  ): Promise<VulnerabilityAlert[]> {
-    // NOTE: Changes to this must be synced with VulnerabilityAlertsQueryResult.
-    const getQuery = (after: string | null) => `{
-  repository(owner: "${owner}", name: "${repo}") {
-    vulnerabilityAlerts(first: 100${
-      after === null ? "" : `, after: "${after}"`
-    }) {
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          state
-          dismissReason
-          vulnerableManifestFilename
-          vulnerableManifestPath
-          vulnerableRequirements
-          securityAdvisory {
-            description
-            identifiers { type value }
-            references { url }
-            severity
-          }
-          securityVulnerability {
-            package { name ecosystem }
-            firstPatchedVersion { identifier }
-            vulnerableVersionRange
-          }
-        }
-      }
-    }
-  }
-}`
-
-    return this.cache.json(
-      `vulnerability-alerts-${owner}-${repo}`,
-      async () => {
-        const result: VulnerabilityAlert[] = []
-        let after = null
-
-        while (true) {
-          const query = getQuery(after)
-          const res =
-            await this.runGraphqlQuery<VulnerabilityAlertsQueryResult>(query)
-
-          result.push(
-            ...(res.repository?.vulnerabilityAlerts.edges?.map(
-              (it) => it.node,
-            ) ?? []),
-          )
-
-          if (!res.repository?.vulnerabilityAlerts.pageInfo.hasNextPage) {
-            break
-          }
-
-          after = res.repository?.vulnerabilityAlerts.pageInfo.endCursor
-        }
-
-        return result
-      },
-    )
   }
 
   /**

--- a/packages/repo-collector/src/github/types.ts
+++ b/packages/repo-collector/src/github/types.ts
@@ -1,33 +1,3 @@
-// See https://developer.github.com/v4/object/repositoryvulnerabilityalert/
-export interface VulnerabilityAlert {
-  dismissReason: string | null
-  state: "DISMISSED" | "FIXED" | "OPEN"
-  vulnerableManifestFilename: string
-  vulnerableManifestPath: string
-  vulnerableRequirements: string | null
-  securityAdvisory: {
-    description: string
-    identifiers: Array<{
-      type: string
-      value: string
-    }>
-    references: Array<{
-      url: string // URI
-    }>
-    severity: "CRITICAL" | "HIGH" | "LOW" | "MODERATE"
-  } | null
-  securityVulnerability: {
-    package: {
-      name: string
-      ecosystem: "COMPOSER" | "MAVEN" | "NPM" | "NUGET" | "PIP" | "RUBYGEMS"
-    }
-    firstPatchedVersion: {
-      identifier: string
-    }
-    vulnerableVersionRange: string
-  } | null
-}
-
 export type Permission = "admin" | "push" | "pull"
 
 export interface RenovateDependencyDashboardIssue {

--- a/packages/repo-collector/src/reporter/reporter.test.ts
+++ b/packages/repo-collector/src/reporter/reporter.test.ts
@@ -23,7 +23,6 @@ function repo(overrides: Partial<SnapshotMetrics> = {}): SnapshotMetrics {
       orgName: "org",
       repoName: "repo",
       prs: [],
-      vulnerabilityAlerts: [],
       renovateDependencyDashboardIssue: null,
     },
     ...overrides,
@@ -90,7 +89,6 @@ describe("findOldPrs", () => {
         github: {
           orgName: "org",
           repoName: "repo",
-          vulnerabilityAlerts: [],
           renovateDependencyDashboardIssue: null,
           prs: [
             {
@@ -131,7 +129,6 @@ describe("findOldPrs", () => {
         github: {
           orgName: "org",
           repoName: "repo",
-          vulnerabilityAlerts: [],
           renovateDependencyDashboardIssue: null,
           prs: [
             {
@@ -305,7 +302,6 @@ describe("buildPerTeamMessages", () => {
             orgName: "liflig",
             repoName: "liflig-logging",
             prs: [],
-            vulnerabilityAlerts: [],
             renovateDependencyDashboardIssue: null,
           },
           responsible: "team-a",

--- a/packages/repo-collector/src/snapshots/collect.ts
+++ b/packages/repo-collector/src/snapshots/collect.ts
@@ -36,10 +36,6 @@ async function createSnapshotData(
     .filter((it) => it.repo.archived !== true)
     .map((it) => ({
       repo: it,
-      githubVulnerabilityAlerts: githubService.getVulnerabilityAlerts(
-        it.orgName,
-        it.repo.name,
-      ),
       renovateDependencyDashboardIssue:
         githubService.getRenovateDependencyDashboardIssue(
           it.orgName,
@@ -88,7 +84,6 @@ async function createSnapshotData(
         prs,
         renovateDependencyDashboardIssue:
           (await repo.renovateDependencyDashboardIssue) ?? null,
-        vulnerabilityAlerts: await repo.githubVulnerabilityAlerts,
       },
       sonarCloud: await repo.sonarCloudMetrics,
       aikido:

--- a/packages/repo-collector/src/webapp/webapp.ts
+++ b/packages/repo-collector/src/webapp/webapp.ts
@@ -58,16 +58,6 @@ function mapSnapshotMetricToWebappMetrics(
         title: pr.title,
         createdAt: pr.createdAt,
       })),
-      vulnerabilityAlerts: snapshotMetrics.github.vulnerabilityAlerts
-        .filter((it) =>
-          it.state == null ? it.dismissReason == null : it.state === "OPEN",
-        )
-        .map((va) => ({
-          vulnerableManifestPath: va.vulnerableManifestPath,
-          severity: va.securityAdvisory?.severity,
-          packageName:
-            va.securityVulnerability?.package.name ?? "unknown-package",
-        })),
     },
     sonarCloud: {
       enabled: !!snapshotMetrics.sonarCloud,

--- a/packages/webapp/src/DataGroup.tsx
+++ b/packages/webapp/src/DataGroup.tsx
@@ -8,7 +8,6 @@ interface Props {
   showPrList: boolean
   showBotPrList: boolean
   showDepList: boolean
-  showVulGithubList: boolean
   showVulAikidoList: boolean
   showOrgName: boolean
   sortByRenovateDays: boolean
@@ -22,7 +21,6 @@ export const DataGroup: React.FC<Props> = ({
   showPrList,
   showBotPrList,
   showDepList,
-  showVulGithubList,
   showVulAikidoList,
   showOrgName,
   sortByRenovateDays,
@@ -64,7 +62,6 @@ export const DataGroup: React.FC<Props> = ({
             showPrList,
             showBotPrList,
             showDepList,
-            showVulGithubList,
             showVulAikidoList,
             showOrgName,
             showRenovateDays: sortByRenovateDays,

--- a/packages/webapp/src/DataList.tsx
+++ b/packages/webapp/src/DataList.tsx
@@ -10,7 +10,7 @@ import { DataGroup } from "./DataGroup"
 import { ENABLE_GLOBAL_STATS, ENABLE_SORT_BY_RENOVATE_DAYS, type Filter } from "./filter"
 import { toQueryString } from "./filter"
 import { FilterActionType, filterReducer } from "./filterReducer"
-import { isActionableRepo, isVulnerableRepo } from "./Repo"
+import { isActionableRepo } from "./Repo"
 import { isBotPr } from "./prUtils"
 import { buildMarkdownSummary } from "./copyUtils"
 
@@ -36,13 +36,11 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
     )
       return false
     const anyFilterActive =
-      state.showOnlyWithPrs || state.showOnlyWithBotPrs ||
-      state.showOnlyWithGithubVul
+      state.showOnlyWithPrs || state.showOnlyWithBotPrs
     if (anyFilterActive) {
       const matchesPrs = state.showOnlyWithPrs && repo.metrics.github.prs.some((p) => !isBotPr(p))
       const matchesBotPrs = state.showOnlyWithBotPrs && repo.metrics.github.prs.some((p) => isBotPr(p))
-      const matchesGithubVul = state.showOnlyWithGithubVul && repo.metrics.github.vulnerabilityAlerts.length > 0
-      if (!matchesPrs && !matchesBotPrs && !matchesGithubVul) return false
+      if (!matchesPrs && !matchesBotPrs) return false
     }
     return true
   }
@@ -57,8 +55,8 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
   }
 
   function filterByVulnerability(repo: Repo): boolean {
-    return repo.metrics.github.vulnerabilityAlerts.some((a) =>
-      a.packageName.toLowerCase().includes(vulSearch),
+    return repo.metrics.aikido.issues.some((i) =>
+      i.title.toLowerCase().includes(vulSearch),
     )
   }
 
@@ -105,7 +103,7 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
         prs: sumBy(repos, (it) => it.metrics.github.prs.length),
         vulnerabilities: sumBy(
           repos,
-          (it) => it.metrics.github.vulnerabilityAlerts.length,
+          (it) => it.metrics.aikido.issues.length,
         ),
       }))
       .sort((a, b) => a.groupKey.localeCompare(b.groupKey))
@@ -120,7 +118,7 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
         prs: sumBy(repos, (it) => it.metrics.github.prs.length),
         vulnerabilities: sumBy(
           repos,
-          (it) => it.metrics.github.vulnerabilityAlerts.length,
+          (it) => it.metrics.aikido.issues.length,
         ),
       }))
       .sort((a, b) => a.groupKey.localeCompare(b.groupKey))
@@ -326,13 +324,13 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
           </div>
           <button
             type="button"
-            className={`todo-btn${state.showOnlyWithPrs && state.showOnlyWithBotPrs && state.showOnlyWithGithubVul ? " todo-btn-active" : ""}`}
+            className={`todo-btn${state.showOnlyWithPrs && state.showOnlyWithBotPrs ? " todo-btn-active" : ""}`}
             onClick={() => {
-              const allOn = state.showOnlyWithPrs && state.showOnlyWithBotPrs && state.showOnlyWithGithubVul
+              const allOn = state.showOnlyWithPrs && state.showOnlyWithBotPrs
               dispatch({
                 type: FilterActionType.SET_BOOLEANS,
                 prop: String(!allOn),
-                payload: "showOnlyWithPrs,showOnlyWithBotPrs,showOnlyWithGithubVul",
+                payload: "showOnlyWithPrs,showOnlyWithBotPrs",
               })
             }}
           >
@@ -351,12 +349,6 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
               onCheck={createOnCheckHandler("showOnlyWithBotPrs")}
             >
               Har bot-PRs
-            </Checkbox>
-            <Checkbox
-              checked={state.showOnlyWithGithubVul}
-              onCheck={createOnCheckHandler("showOnlyWithGithubVul")}
-            >
-              Har GitHub-sårbarheter
             </Checkbox>
           </div>
           <div className="filter-group">
@@ -378,12 +370,6 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
               onCheck={createOnCheckHandler("showBotPrList")}
             >
               Bot PR
-            </Checkbox>
-            <Checkbox
-              checked={state.showVulGithubList}
-              onCheck={createOnCheckHandler("showVulGithubList")}
-            >
-              Sårbarheter (GitHub)
             </Checkbox>
             <Checkbox
               checked={state.showVulAikidoList}
@@ -470,7 +456,6 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
               showPrList={state.showPrList}
               showBotPrList={state.showBotPrList}
               showDepList={state.showDepList}
-              showVulGithubList={state.showVulGithubList}
               showVulAikidoList={state.showVulAikidoList}
               showOrgName={state.showOrgName}
               sortByRenovateDays={state.sortByRenovateDays}
@@ -576,11 +561,6 @@ const SectionHeader: React.FC<{
         c.isActionable ? c.updates : [],
       ).length,
   )
-  const githubVul = sumBy(
-    repos,
-    (it) => it.metrics.github.vulnerabilityAlerts.length,
-  )
-
   const prs = sumBy(repos, (it) => it.metrics.github.prs.filter((p) => !isBotPr(p)).length)
   const botPrs = sumBy(repos, (it) => it.metrics.github.prs.filter((p) => isBotPr(p)).length)
 
@@ -601,9 +581,6 @@ const SectionHeader: React.FC<{
         <span className={`section-badge ${botPrs > 0 ? "badge-pr" : "badge-ok"}`}>
           {botPrs} bot PR
         </span>
-        <span className={`section-badge ${githubVul > 0 ? "badge-vuln" : "badge-ok"}`}>
-          {githubVul} github
-        </span>
       </div>
     </div>
   )
@@ -619,12 +596,11 @@ const GlobalStats: React.FC<{ repos: Repo[] }> = ({ repos }) => {
         c.isActionable ? c.updates : [],
       ).length,
   )
-  const githubVul = sumBy(
-    repos,
-    (r) => r.metrics.github.vulnerabilityAlerts.length,
-  )
+  const aikidoVul = sumBy(repos, (r) => r.metrics.aikido.issues.length)
   const actionable = repos.filter((r) => isActionableRepo(r.metrics)).length
-  const vulnerable = repos.filter((r) => isVulnerableRepo(r.metrics)).length
+  const vulnerable = repos.filter(
+    (r) => r.metrics.aikido.issues.length > 0,
+  ).length
 
   return (
     <div className="filter-group">
@@ -636,7 +612,7 @@ const GlobalStats: React.FC<{ repos: Repo[] }> = ({ repos }) => {
         </div>
         <div className="global-stat">
           <span className="global-stat-value">{actionable}</span>
-          <span className="global-stat-label">med oppdateringer/bot-PRs/sårbarheter</span>
+          <span className="global-stat-label">med oppdateringer/bot-PRs</span>
         </div>
         <div className="global-stat">
           <span className="global-stat-value">{totalPrs}</span>
@@ -651,7 +627,7 @@ const GlobalStats: React.FC<{ repos: Repo[] }> = ({ repos }) => {
           <span className="global-stat-label">sårbare repoer</span>
         </div>
         <div className="global-stat stat-danger">
-          <span className="global-stat-value">{githubVul}</span>
+          <span className="global-stat-value">{aikidoVul}</span>
           <span className="global-stat-label">sårbarheter</span>
         </div>
       </div>

--- a/packages/webapp/src/Repo.tsx
+++ b/packages/webapp/src/Repo.tsx
@@ -14,7 +14,6 @@ export const repoColumns = (props: {
   showPrList: boolean
   showBotPrList: boolean
   showDepList: boolean
-  showVulGithubList: boolean
   showVulAikidoList: boolean
   showOrgName: boolean
   showRenovateDays: boolean
@@ -26,7 +25,6 @@ export const repoColumns = (props: {
     showPrList,
     showBotPrList,
     showDepList,
-    showVulGithubList,
     showVulAikidoList,
     showOrgName,
     showRenovateDays,
@@ -177,54 +175,6 @@ export const repoColumns = (props: {
     },
     {
       header: "Sårbarheter",
-      subheader: "GitHub",
-      headerIcon: <SecurityIcon />,
-      width: "9%",
-      sortOn: (repo) => repo.metrics.github.vulnerabilityAlerts.length,
-      render: (repo, isExpanded) => {
-        const githubVulAlerts = repo.metrics.github.vulnerabilityAlerts
-        const dependabotUrl = `${repoBaseUrl(repo)}/security/dependabot`
-        if (githubVulAlerts.length === 0) {
-          return <a href={dependabotUrl} className="state-ok">Ingen</a>
-        }
-        const hasVulSearch = filterVulName !== ""
-        const matchingAlerts = hasVulSearch
-          ? githubVulAlerts.filter((a) =>
-              a.packageName.toLowerCase().includes(filterVulName.toLowerCase()),
-            )
-          : []
-        const showDetails = showVulGithubList || isExpanded || matchingAlerts.length > 0
-        if (!showDetails) {
-          return (
-            <a href={dependabotUrl}>
-              <b>{githubVulAlerts.length}</b>
-            </a>
-          )
-        }
-        const alertsToGroup = showVulGithubList || isExpanded ? githubVulAlerts : matchingAlerts
-        const grouped = groupVulnsByPackage(alertsToGroup)
-        return (
-          <ul className="detail-list">
-            {grouped.map((group, idx) => (
-              <li key={idx} className="detail-item">
-                <span className="detail-index">{idx + 1}</span>
-                <a href={dependabotUrl}><Highlight text={group.packageName} search={filterVulName} /></a>
-                {group.count > 1 && (
-                  <span className="detail-meta">&times;{group.count}</span>
-                )}
-                {group.highestSeverity && (
-                  <span className={`detail-severity severity-${group.highestSeverity.toLowerCase()}`}>
-                    {group.highestSeverity}
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
-        )
-      },
-    },
-    {
-      header: "Sårbarheter",
       subheader: "Aikido",
       headerIcon: <SecurityIcon />,
       width: "9%",
@@ -315,35 +265,6 @@ export const repoColumns = (props: {
   ]
 }
 
-const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MODERATE", "LOW"] as const
-
-type Severity = "CRITICAL" | "HIGH" | "LOW" | "MODERATE"
-
-function groupVulnsByPackage(
-  alerts: { packageName: string; severity?: Severity }[],
-) {
-  const map = new Map<string, { count: number; highestSeverity?: Severity }>()
-  for (const alert of alerts) {
-    const existing = map.get(alert.packageName)
-    if (existing) {
-      existing.count++
-      if (alert.severity && (!existing.highestSeverity ||
-        SEVERITY_ORDER.indexOf(alert.severity) < SEVERITY_ORDER.indexOf(existing.highestSeverity))) {
-        existing.highestSeverity = alert.severity
-      }
-    } else {
-      map.set(alert.packageName, { count: 1, highestSeverity: alert.severity })
-    }
-  }
-  return [...map.entries()]
-    .map(([packageName, { count, highestSeverity }]) => ({ packageName, count, highestSeverity }))
-    .sort((a, b) => {
-      const ai = a.highestSeverity ? SEVERITY_ORDER.indexOf(a.highestSeverity) : 999
-      const bi = b.highestSeverity ? SEVERITY_ORDER.indexOf(b.highestSeverity) : 999
-      return ai - bi || a.packageName.localeCompare(b.packageName)
-    })
-}
-
 const AIKIDO_SEVERITY_ORDER: AikidoSeverity[] = [
   "critical",
   "high",
@@ -421,13 +342,8 @@ export function isActionableRepo(repo: Metrics): boolean {
   return (
     (repo.github.availableUpdates ?? []).filter((it) => it.isActionable)
       .length > 0 ||
-    repo.github.prs.filter((it) => isBotPr(it)).length > 0 ||
-    isVulnerableRepo(repo)
+    repo.github.prs.filter((it) => isBotPr(it)).length > 0
   )
-}
-
-export function isVulnerableRepo(repo: Metrics): boolean {
-  return repo.github.vulnerabilityAlerts.length > 0
 }
 
 function coverageClass(coverage: string): string {

--- a/packages/webapp/src/copyUtils.ts
+++ b/packages/webapp/src/copyUtils.ts
@@ -28,23 +28,20 @@ export function buildMarkdownSummary({
     .map((repo) => {
       const prs = repo.metrics.github.prs.filter((p) => !isBotPr(p)).length
       const botPrs = repo.metrics.github.prs.filter((p) => isBotPr(p)).length
-      const ghVul = repo.metrics.github.vulnerabilityAlerts.length
-      return { name: repo.name, prs, botPrs, ghVul }
+      return { name: repo.name, prs, botPrs }
     })
-    .filter((r) => r.prs > 0 || r.botPrs > 0 || r.ghVul > 0)
+    .filter((r) => r.prs > 0 || r.botPrs > 0)
 
   if (rows.length === 0) {
     lines.push("Ingen aktive saker.")
     return lines.join("\n")
   }
 
-  lines.push("| Repo | PRs | Bot PRs | GitHub Vul |")
-  lines.push("| --- | --- | --- | --- |")
+  lines.push("| Repo | PRs | Bot PRs |")
+  lines.push("| --- | --- | --- |")
   for (const r of rows) {
     const cell = (n: number) => (n > 0 ? String(n) : "")
-    lines.push(
-      `| ${r.name} | ${cell(r.prs)} | ${cell(r.botPrs)} | ${cell(r.ghVul)} |`,
-    )
+    lines.push(`| ${r.name} | ${cell(r.prs)} | ${cell(r.botPrs)} |`)
   }
   lines.push("")
 

--- a/packages/webapp/src/filter.ts
+++ b/packages/webapp/src/filter.ts
@@ -8,12 +8,10 @@ export interface Filter
   showPrList: boolean
   showBotPrList: boolean
   showDepList: boolean
-  showVulGithubList: boolean
   showVulAikidoList: boolean
   showOrgName: boolean
   showOnlyWithPrs: boolean
   showOnlyWithBotPrs: boolean
-  showOnlyWithGithubVul: boolean
   sortByRenovateDays: boolean
   selectedTeams: string[]
   filterRepoName: string
@@ -26,12 +24,10 @@ export const defaultValues: Filter = {
   showPrList: false,
   showBotPrList: false,
   showDepList: false,
-  showVulGithubList: false,
   showVulAikidoList: false,
   showOrgName: false,
   showOnlyWithPrs: false,
   showOnlyWithBotPrs: false,
-  showOnlyWithGithubVul: false,
   sortByRenovateDays: false,
   selectedTeams: [],
   filterRepoName: "",

--- a/packages/webapp/src/styles/main.css
+++ b/packages/webapp/src/styles/main.css
@@ -321,7 +321,6 @@ td:hover .renovate-logs-link {
 
 .severity-critical { background: var(--color-badge-vuln-bg); color: var(--color-aikido-critical); }
 .severity-high { background: var(--color-badge-vuln-bg); color: var(--color-aikido-high); }
-.severity-moderate,
 .severity-medium { background: var(--color-badge-pr-bg); color: var(--color-warning); }
 .severity-low { background: var(--color-secondary); color: var(--color-mute); }
 


### PR DESCRIPTION
Aikido now covers vulnerability reporting, making the GitHub Dependabot alerts redundant.

- Drop `vulnerabilityAlerts` from snapshot + webapp types
- Remove the `getVulnerabilityAlerts` GraphQL collection
- Remove the GitHub vulnerabilities column, filters and stats
- Point the shared vuln search + summary stats at Aikido data
