### PR TITLE
fix(webapp): polish repo detail sidebar

### DIFF
--- a/packages/webapp/src/RepoSidebar.tsx
+++ b/packages/webapp/src/RepoSidebar.tsx
@@ -30,6 +30,14 @@ function aikidoIssueUrl(repoId: number | null, groupId: number): string {
     : `https://app.aikido.dev/queue?sidebarIssue=${groupId}`
 }
 
+// Mirrors the main table's coverage colour thresholds.
+function coverageClass(coverage: string): string {
+  const val = Number.parseInt(coverage, 10)
+  if (val > 70) return "coverage-good"
+  if (val > 45) return "coverage-mid"
+  return "coverage-low"
+}
+
 // Human-readable labels for Aikido issue types. Unknown types fall back to a
 // title-cased version of the raw value (e.g. "some_new_type" -> "Some New Type").
 const ISSUE_TYPE_LABELS: Record<string, string> = {
@@ -257,9 +265,11 @@ export const RepoSidebar: React.FC<Props> = ({ repo, onClose }) => {
 
       <Section icon={<SonarCloudIcon />} title="Coverage (SonarCloud)">
         {coverage ? (
-          <p className="repo-sidebar-note">
-            Test coverage: <strong>{coverage}%</strong>
-          </p>
+          <span
+            className={`repo-sidebar-coverage ${coverageClass(coverage)}`}
+          >
+            {coverage}%
+          </span>
         ) : (
           <p className="repo-sidebar-empty">No coverage reported.</p>
         )}

--- a/packages/webapp/src/styles/main.css
+++ b/packages/webapp/src/styles/main.css
@@ -674,23 +674,15 @@ button:hover {
 
 /* ── Repo detail sidebar ── */
 
-/* Flex slot that pushes and shrinks the table rather than overlaying it.
-   Collapses to zero width when no repo is selected (panel is empty). */
+/* Static flex slot that holds the always-open detail panel, shrinking the
+   table to the remaining width rather than overlaying it. */
 .detail-panel {
   flex: 0 0 40%;
   max-width: 40%;
   overflow: hidden;
-  transition: flex-basis 0.18s ease, max-width 0.18s ease;
-}
-
-.detail-panel:empty {
-  flex-basis: 0;
-  max-width: 0;
 }
 
 .repo-sidebar {
-  /* Keep content at its target width so the reveal wipes in without
-     reflowing text as the slot animates open. */
   width: 40vw;
   min-width: 340px;
   height: 100%;
@@ -869,6 +861,13 @@ button:hover {
   margin: 0;
   font-size: 13px;
   color: var(--color-ok);
+}
+
+.repo-sidebar-coverage {
+  font-size: 22px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
 
 /* Tables inside the detail panel (PRs, vulnerabilities) */


### PR DESCRIPTION
Follow-up polish to the repo detail sidebar (#406).

- Panel no longer slides open on page load (it is always open)
- Coverage shown as a prominent, colour-coded number
