### PR TITLE
feat(webapp): refine repo filters and deep-link repo + SonarCloud

### DIFF
--- a/packages/webapp/src/DataGroup.tsx
+++ b/packages/webapp/src/DataGroup.tsx
@@ -5,10 +5,6 @@ import Table from "./Table"
 
 interface Props {
   repos: Repo[]
-  showPrList: boolean
-  showBotPrList: boolean
-  showVulAikidoList: boolean
-  showOrgName: boolean
   sortByRenovateDays: boolean
   filterRepoName: string
   filterUpdateName: string
@@ -20,10 +16,6 @@ interface Props {
 
 export const DataGroup: React.FC<Props> = ({
   repos,
-  showPrList,
-  showBotPrList,
-  showVulAikidoList,
-  showOrgName,
   sortByRenovateDays,
   filterRepoName,
   filterUpdateName,
@@ -65,10 +57,6 @@ export const DataGroup: React.FC<Props> = ({
           onRowClick={onSelectRepo}
           selectedKey={selectedRepoId}
           columns={repoColumns({
-            showPrList,
-            showBotPrList,
-            showVulAikidoList,
-            showOrgName,
             filterRepoName,
             filterUpdateName,
             filterVulName,

--- a/packages/webapp/src/DataList.tsx
+++ b/packages/webapp/src/DataList.tsx
@@ -17,6 +17,13 @@ import { buildMarkdownSummary } from "./copyUtils"
 
 const NONE_SENTINEL = "__none__"
 
+// Filters activated by the TODO button: repos with anything to triage.
+const TODO_FILTERS: (keyof Filter)[] = [
+  "showOnlyWithPrs",
+  "showOnlyWithBotPrs",
+  "showOnlyWithVulns",
+]
+
 interface Props {
   data: WebappData
   filter: Filter
@@ -24,8 +31,14 @@ interface Props {
 
 export const DataList: React.FC<Props> = ({ data, filter }) => {
   const [state, dispatch] = React.useReducer(filterReducer, filter)
+  // Initialise the selected repo from the `?selectedRepo=<name>` URL param so
+  // the detail sidebar is deep-linkable. Matched by repo name, not id.
   const [selectedRepoId, setSelectedRepoId] = React.useState<string | null>(
-    null,
+    () => {
+      const name = new URLSearchParams(location.search).get("selectedRepo")
+      if (!name) return null
+      return data.repos.find((r) => r.name === name)?.id ?? null
+    },
   )
 
   const selectedRepo = React.useMemo(
@@ -40,9 +53,13 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
   )
 
   React.useEffect(() => {
-    const queryString = toQueryString(state)
-    history.replaceState(state, "", queryString ? `?${queryString}` : "/")
-  }, [state])
+    const parts = [toQueryString(state)].filter(Boolean)
+    if (selectedRepo) {
+      parts.push(`selectedRepo=${encodeURIComponent(selectedRepo.name)}`)
+    }
+    const queryString = parts.join("&")
+    history.replaceState(null, "", queryString ? `?${queryString}` : "/")
+  }, [state, selectedRepo])
 
   function filterRepo(repo: Repo): boolean {
     if (
@@ -344,13 +361,13 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
           </div>
           <button
             type="button"
-            className={`todo-btn${state.showOnlyWithPrs && state.showOnlyWithBotPrs ? " todo-btn-active" : ""}`}
+            className={`todo-btn${TODO_FILTERS.every((f) => state[f]) ? " todo-btn-active" : ""}`}
             onClick={() => {
-              const allOn = state.showOnlyWithPrs && state.showOnlyWithBotPrs
+              const allOn = TODO_FILTERS.every((f) => state[f])
               dispatch({
                 type: FilterActionType.SET_BOOLEANS,
                 prop: String(!allOn),
-                payload: "showOnlyWithPrs,showOnlyWithBotPrs",
+                payload: TODO_FILTERS.join(","),
               })
             }}
           >
@@ -383,41 +400,17 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
               Missing coverage
             </Checkbox>
           </div>
-          <div className="filter-group">
-            <span className="filter-group-label">Show details</span>
-            <Checkbox
-              checked={state.showPrList}
-              onCheck={createOnCheckHandler("showPrList")}
-            >
-              PRs
-            </Checkbox>
-            <Checkbox
-              checked={state.showBotPrList}
-              onCheck={createOnCheckHandler("showBotPrList")}
-            >
-              Bot PR
-            </Checkbox>
-            <Checkbox
-              checked={state.showVulAikidoList}
-              onCheck={createOnCheckHandler("showVulAikidoList")}
-            >
-              Vulnerabilities (Aikido)
-            </Checkbox>
-            <Checkbox
-              checked={state.showOrgName}
-              onCheck={createOnCheckHandler("showOrgName")}
-            >
-              GitHub organization
-            </Checkbox>
-            {ENABLE_SORT_BY_RENOVATE_DAYS && (
+          {ENABLE_SORT_BY_RENOVATE_DAYS && (
+            <div className="filter-group">
+              <span className="filter-group-label">Sort</span>
               <Checkbox
                 checked={state.sortByRenovateDays}
                 onCheck={createOnCheckHandler("sortByRenovateDays")}
               >
                 Sort by Renovate days
               </Checkbox>
-            )}
-          </div>
+            </div>
+          )}
           <div className="filter-group">
             <span className="filter-group-label">
               {state.groupBy === "system" ? "System Stats" : "Team Stats"}
@@ -479,10 +472,6 @@ export const DataList: React.FC<Props> = ({ data, filter }) => {
             />
             <DataGroup
               repos={repos}
-              showPrList={state.showPrList}
-              showBotPrList={state.showBotPrList}
-              showVulAikidoList={state.showVulAikidoList}
-              showOrgName={state.showOrgName}
               sortByRenovateDays={state.sortByRenovateDays}
               filterRepoName={state.filterRepoName}
               filterUpdateName={state.filterUpdateName}

--- a/packages/webapp/src/PrColumnDetails.tsx
+++ b/packages/webapp/src/PrColumnDetails.tsx
@@ -6,14 +6,12 @@ import { Highlight } from "./Highlight"
 interface Props {
   prs: Metrics["github"]["prs"]
   repoBaseUrl: string
-  showPrList: boolean
   filterUpdateName: string
 }
 
 export const PrColumnDetails: React.FC<Props> = ({
   prs,
   repoBaseUrl,
-  showPrList,
   filterUpdateName,
 }) => {
   if (prs.length === 0) {
@@ -29,9 +27,7 @@ export const PrColumnDetails: React.FC<Props> = ({
       )
     : []
 
-  const showAll = showPrList
-  const showMatches = !showAll && matchingPrs.length > 0
-  const prsToShow = showAll ? prs : showMatches ? matchingPrs : []
+  const prsToShow = matchingPrs.length > 0 ? matchingPrs : []
 
   if (prsToShow.length > 0) {
     return (

--- a/packages/webapp/src/Repo.tsx
+++ b/packages/webapp/src/Repo.tsx
@@ -10,10 +10,6 @@ import { isBotPr } from "./prUtils"
 import type { Column } from "./Table"
 
 export const repoColumns = (props: {
-  showPrList: boolean
-  showBotPrList: boolean
-  showVulAikidoList: boolean
-  showOrgName: boolean
   filterRepoName: string
   filterUpdateName: string
   filterVulName: string
@@ -25,10 +21,6 @@ export const repoColumns = (props: {
   compact?: boolean
 }): Column<Repo>[] => {
   const {
-    showPrList,
-    showBotPrList,
-    showVulAikidoList,
-    showOrgName,
     filterRepoName,
     filterUpdateName,
     filterVulName,
@@ -45,27 +37,23 @@ export const repoColumns = (props: {
       render: (repo, _isExpanded) => {
         return (
           <span className="repo-link" title={repo.name}>
-            {showOrgName && (
-              <span className="repo-org"><Highlight text={repo.org} search={filterRepoName} />/</span>
-            )}
             <span className="repo-name"><Highlight text={repo.name} search={filterRepoName} /></span>
           </span>
         )
       },
     },
     {
-      header: "PRs",
+      header: "PR",
       headerIcon: <PrIcon />,
       width: compact ? "13%" : "22%",
       align: "right",
       sortOn: (repo) =>
         repo.metrics.github.prs.filter((it) => !isBotPr(it)).length,
-      render: (repo, isExpanded) => {
+      render: (repo, _isExpanded) => {
         return (
           <PrColumnDetails
             prs={repo.metrics.github.prs.filter((it) => !isBotPr(it))}
             repoBaseUrl={repoBaseUrl(repo)}
-            showPrList={showPrList || isExpanded}
             filterUpdateName={filterUpdateName}
           />
         )
@@ -78,12 +66,11 @@ export const repoColumns = (props: {
       align: "right",
       sortOn: (repo) =>
         repo.metrics.github.prs.filter((it) => isBotPr(it)).length,
-      render: (repo, isExpanded) => {
+      render: (repo, _isExpanded) => {
         return (
           <PrColumnDetails
             prs={repo.metrics.github.prs.filter((it) => isBotPr(it))}
             repoBaseUrl={repoBaseUrl(repo)}
-            showPrList={showBotPrList || isExpanded}
             filterUpdateName={filterUpdateName}
           />
         )
@@ -96,7 +83,7 @@ export const repoColumns = (props: {
       width: compact ? "17%" : "9%",
       align: "right",
       sortOn: (repo) => aikidoSortValue(repo.metrics.aikido.issues),
-      render: (repo, isExpanded) => {
+      render: (repo, _isExpanded) => {
         const aikido = repo.metrics.aikido
         if (!aikido.enabled) {
           return <span className="state-missing" title="No data">—</span>
@@ -118,14 +105,12 @@ export const repoColumns = (props: {
               i.title.toLowerCase().includes(filterVulName.toLowerCase()),
             )
           : []
-        const showDetails =
-          showVulAikidoList || isExpanded || matchingIssues.length > 0
+        const showDetails = matchingIssues.length > 0
         if (!showDetails) {
           return summary
         }
 
-        const listed =
-          showVulAikidoList || isExpanded ? aikido.issues : matchingIssues
+        const listed = matchingIssues
         const sorted = [...listed].sort(
           (a, b) =>
             AIKIDO_SEVERITY_ORDER.indexOf(a.severity) -

--- a/packages/webapp/src/RepoSidebar.tsx
+++ b/packages/webapp/src/RepoSidebar.tsx
@@ -24,6 +24,12 @@ const AIKIDO_SEVERITY_ORDER: AikidoSeverity[] = [
 const repoBaseUrl = (repo: Repo) =>
   `https://github.com/${repo.org}/${repo.name}`
 
+// SonarCloud project keys are deterministically `<org>_<name>` (see the
+// collector's `getMetricsByProjectKey` call), so the dashboard link can be
+// reconstructed on the frontend without carrying the key through the pipeline.
+const sonarCloudProjectUrl = (repo: Repo) =>
+  `https://sonarcloud.io/summary/overall?id=${encodeURIComponent(`${repo.org}_${repo.name}`)}`
+
 function aikidoIssueUrl(repoId: number | null, groupId: number): string {
   return repoId != null
     ? `https://app.aikido.dev/repositories/${repoId}?sidebarIssue=${groupId}`
@@ -128,7 +134,8 @@ export const RepoSidebar: React.FC<Props> = ({ repo, onClose }) => {
       a.title.localeCompare(b.title),
   )
 
-  const coverage = repo.metrics.sonarCloud.testCoverage
+  const sonarCloud = repo.metrics.sonarCloud
+  const coverage = sonarCloud.testCoverage
   // Renovate's own dashboard links here for the repo's run logs (Mend portal).
   const mendUrl = `https://app.renovatebot.com/dashboard#github/${encodeURI(repo.id)}`
 
@@ -264,14 +271,29 @@ export const RepoSidebar: React.FC<Props> = ({ repo, onClose }) => {
       </Section>
 
       <Section icon={<SonarCloudIcon />} title="Coverage (SonarCloud)">
-        {coverage ? (
-          <span
-            className={`repo-sidebar-coverage ${coverageClass(coverage)}`}
-          >
-            {coverage}%
-          </span>
+        {sonarCloud.enabled ? (
+          <>
+            {coverage ? (
+              <span
+                className={`repo-sidebar-coverage ${coverageClass(coverage)}`}
+              >
+                {coverage}%
+              </span>
+            ) : (
+              <p className="repo-sidebar-empty">No coverage reported.</p>
+            )}
+            <p className="repo-sidebar-note">
+              <a
+                href={sonarCloudProjectUrl(repo)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open in SonarCloud
+              </a>
+            </p>
+          </>
         ) : (
-          <p className="repo-sidebar-empty">No coverage reported.</p>
+          <p className="repo-sidebar-empty">Not set up in SonarCloud.</p>
         )}
       </Section>
 

--- a/packages/webapp/src/filter.ts
+++ b/packages/webapp/src/filter.ts
@@ -5,10 +5,6 @@ export const ENABLE_GLOBAL_STATS = false
 
 export interface Filter
   extends Record<string, boolean | string | string[] | number> {
-  showPrList: boolean
-  showBotPrList: boolean
-  showVulAikidoList: boolean
-  showOrgName: boolean
   showOnlyWithPrs: boolean
   showOnlyWithBotPrs: boolean
   showOnlyWithVulns: boolean
@@ -22,10 +18,6 @@ export interface Filter
 }
 
 export const defaultValues: Filter = {
-  showPrList: false,
-  showBotPrList: false,
-  showVulAikidoList: false,
-  showOrgName: false,
   showOnlyWithPrs: false,
   showOnlyWithBotPrs: false,
   showOnlyWithVulns: false,


### PR DESCRIPTION
- Rename "PRs" table column to "PR".
- TODO button toggles PR, bot-PR and vuln filters and reflects their combined state.
- Remove inline "Show details" toggles, superseded by the detail sidebar; drop their URL keywords.
- Deep-link the selected repo via `?selectedRepo=<name>`.
- Add "Open in SonarCloud" link to the sidebar Coverage section.